### PR TITLE
feat(themes) include dark and light variant of the default neovim theme

### DIFF
--- a/src/themes.rs
+++ b/src/themes.rs
@@ -343,7 +343,7 @@ mod tests {
             assert!(!theme.name.is_empty());
         }
 
-        assert_eq!(ALL_THEMES.len(), 102);
+        assert_eq!(ALL_THEMES.len(), 104);
     }
 
     #[test]

--- a/themes/extract_themes.lua
+++ b/themes/extract_themes.lua
@@ -4,6 +4,18 @@
 
 local themes = {
 	{
+		name = "neovim_dark",
+		colorscheme = "default",
+		appearance = "dark",
+		plugin = {},
+	},
+	{
+		name = "neovim_light",
+		colorscheme = "default",
+		appearance = "light",
+		plugin = {},
+	},
+	{
 		name = "ayu_dark",
 		colorscheme = "ayu-dark",
 		appearance = "dark",

--- a/themes/neovim_dark.json
+++ b/themes/neovim_dark.json
@@ -1,0 +1,304 @@
+{
+  "name": "neovim_dark",
+  "appearance": "dark",
+  "highlights": {
+    "attribute": {
+      "fg": "#e0e2ea"
+    },
+    "attribute.builtin": {
+      "fg": "#8cf8f7"
+    },
+    "boolean": {
+      "fg": "#e0e2ea"
+    },
+    "character": {
+      "fg": "#e0e2ea"
+    },
+    "character.special": {
+      "fg": "#8cf8f7"
+    },
+    "comment": {
+      "fg": "#9b9ea4"
+    },
+    "comment.documentation": {
+      "fg": "#9b9ea4"
+    },
+    "comment.error": {
+      "fg": "#ffc0b9"
+    },
+    "comment.note": {
+      "fg": "#8cf8f7"
+    },
+    "comment.todo": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "comment.warning": {
+      "fg": "#fce094"
+    },
+    "constant": {
+      "fg": "#e0e2ea"
+    },
+    "constant.builtin": {
+      "fg": "#8cf8f7"
+    },
+    "constant.macro": {
+      "fg": "#e0e2ea"
+    },
+    "constructor": {
+      "fg": "#8cf8f7"
+    },
+    "diff.delta": {
+      "fg": "#8cf8f7"
+    },
+    "diff.minus": {
+      "fg": "#ffc0b9"
+    },
+    "diff.plus": {
+      "fg": "#b3f6c0"
+    },
+    "function": {
+      "fg": "#8cf8f7"
+    },
+    "function.builtin": {
+      "fg": "#8cf8f7"
+    },
+    "function.call": {
+      "fg": "#8cf8f7"
+    },
+    "function.macro": {
+      "fg": "#8cf8f7"
+    },
+    "function.method": {
+      "fg": "#8cf8f7"
+    },
+    "function.method.call": {
+      "fg": "#8cf8f7"
+    },
+    "keyword": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "keyword.conditional": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "keyword.conditional.ternary": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "keyword.coroutine": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "keyword.debug": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "keyword.directive": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "keyword.directive.define": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "keyword.exception": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "keyword.function": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "keyword.import": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "keyword.modifier": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "keyword.operator": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "keyword.repeat": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "keyword.return": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "keyword.type": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "label": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "markup.heading": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "markup.heading.1": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "markup.heading.2": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "markup.heading.3": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "markup.heading.4": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "markup.heading.5": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "markup.heading.6": {
+      "fg": "#e0e2ea",
+      "bold": true
+    },
+    "markup.italic": {
+      "italic": true
+    },
+    "markup.link": {
+      "underline": true
+    },
+    "markup.link.label": {
+      "underline": true
+    },
+    "markup.link.url": {
+      "underline": true
+    },
+    "markup.list": {
+      "fg": "#8cf8f7"
+    },
+    "markup.list.checked": {
+      "fg": "#8cf8f7"
+    },
+    "markup.list.unchecked": {
+      "fg": "#8cf8f7"
+    },
+    "markup.math": {
+      "fg": "#8cf8f7"
+    },
+    "markup.quote": {
+      "fg": "#8cf8f7"
+    },
+    "markup.raw": {
+      "fg": "#8cf8f7"
+    },
+    "markup.raw.block": {
+      "fg": "#8cf8f7"
+    },
+    "markup.strikethrough": {
+      "strikethrough": true
+    },
+    "markup.strong": {
+      "bold": true
+    },
+    "markup.underline": {
+      "underline": true
+    },
+    "module": {
+      "fg": "#e0e2ea"
+    },
+    "module.builtin": {
+      "fg": "#8cf8f7"
+    },
+    "normal": {
+      "fg": "#e0e2ea",
+      "bg": "#14161b"
+    },
+    "number": {
+      "fg": "#e0e2ea"
+    },
+    "number.float": {
+      "fg": "#e0e2ea"
+    },
+    "operator": {
+      "fg": "#e0e2ea"
+    },
+    "property": {
+      "fg": "#a6dbff"
+    },
+    "punctuation.bracket": {
+      "fg": "#e0e2ea"
+    },
+    "punctuation.delimiter": {
+      "fg": "#e0e2ea"
+    },
+    "punctuation.special": {
+      "fg": "#8cf8f7"
+    },
+    "string": {
+      "fg": "#b3f6c0"
+    },
+    "string.documentation": {
+      "fg": "#b3f6c0"
+    },
+    "string.escape": {
+      "fg": "#8cf8f7"
+    },
+    "string.regexp": {
+      "fg": "#8cf8f7"
+    },
+    "string.special": {
+      "fg": "#8cf8f7"
+    },
+    "string.special.path": {
+      "fg": "#8cf8f7"
+    },
+    "string.special.symbol": {
+      "fg": "#8cf8f7"
+    },
+    "string.special.url": {
+      "underline": true
+    },
+    "tag": {
+      "fg": "#8cf8f7"
+    },
+    "tag.attribute": {
+      "fg": "#8cf8f7"
+    },
+    "tag.builtin": {
+      "fg": "#8cf8f7"
+    },
+    "tag.delimiter": {
+      "fg": "#8cf8f7"
+    },
+    "type": {
+      "fg": "#e0e2ea"
+    },
+    "type.builtin": {
+      "fg": "#8cf8f7"
+    },
+    "type.definition": {
+      "fg": "#e0e2ea"
+    },
+    "variable": {
+      "fg": "#e0e2ea"
+    },
+    "variable.builtin": {
+      "fg": "#8cf8f7"
+    },
+    "variable.member": {
+      "fg": "#e0e2ea"
+    },
+    "variable.parameter": {
+      "fg": "#e0e2ea"
+    },
+    "variable.parameter.builtin": {
+      "fg": "#8cf8f7"
+    }
+  }
+}

--- a/themes/neovim_light.json
+++ b/themes/neovim_light.json
@@ -1,0 +1,304 @@
+{
+  "name": "neovim_light",
+  "appearance": "light",
+  "highlights": {
+    "attribute": {
+      "fg": "#14161b"
+    },
+    "attribute.builtin": {
+      "fg": "#007373"
+    },
+    "boolean": {
+      "fg": "#14161b"
+    },
+    "character": {
+      "fg": "#14161b"
+    },
+    "character.special": {
+      "fg": "#007373"
+    },
+    "comment": {
+      "fg": "#4f5258"
+    },
+    "comment.documentation": {
+      "fg": "#4f5258"
+    },
+    "comment.error": {
+      "fg": "#590008"
+    },
+    "comment.note": {
+      "fg": "#007373"
+    },
+    "comment.todo": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "comment.warning": {
+      "fg": "#6b5300"
+    },
+    "constant": {
+      "fg": "#14161b"
+    },
+    "constant.builtin": {
+      "fg": "#007373"
+    },
+    "constant.macro": {
+      "fg": "#14161b"
+    },
+    "constructor": {
+      "fg": "#007373"
+    },
+    "diff.delta": {
+      "fg": "#007373"
+    },
+    "diff.minus": {
+      "fg": "#590008"
+    },
+    "diff.plus": {
+      "fg": "#005523"
+    },
+    "function": {
+      "fg": "#007373"
+    },
+    "function.builtin": {
+      "fg": "#007373"
+    },
+    "function.call": {
+      "fg": "#007373"
+    },
+    "function.macro": {
+      "fg": "#007373"
+    },
+    "function.method": {
+      "fg": "#007373"
+    },
+    "function.method.call": {
+      "fg": "#007373"
+    },
+    "keyword": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "keyword.conditional": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "keyword.conditional.ternary": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "keyword.coroutine": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "keyword.debug": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "keyword.directive": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "keyword.directive.define": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "keyword.exception": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "keyword.function": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "keyword.import": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "keyword.modifier": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "keyword.operator": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "keyword.repeat": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "keyword.return": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "keyword.type": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "label": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "markup.heading": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "markup.heading.1": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "markup.heading.2": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "markup.heading.3": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "markup.heading.4": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "markup.heading.5": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "markup.heading.6": {
+      "fg": "#14161b",
+      "bold": true
+    },
+    "markup.italic": {
+      "italic": true
+    },
+    "markup.link": {
+      "underline": true
+    },
+    "markup.link.label": {
+      "underline": true
+    },
+    "markup.link.url": {
+      "underline": true
+    },
+    "markup.list": {
+      "fg": "#007373"
+    },
+    "markup.list.checked": {
+      "fg": "#007373"
+    },
+    "markup.list.unchecked": {
+      "fg": "#007373"
+    },
+    "markup.math": {
+      "fg": "#007373"
+    },
+    "markup.quote": {
+      "fg": "#007373"
+    },
+    "markup.raw": {
+      "fg": "#007373"
+    },
+    "markup.raw.block": {
+      "fg": "#007373"
+    },
+    "markup.strikethrough": {
+      "strikethrough": true
+    },
+    "markup.strong": {
+      "bold": true
+    },
+    "markup.underline": {
+      "underline": true
+    },
+    "module": {
+      "fg": "#14161b"
+    },
+    "module.builtin": {
+      "fg": "#007373"
+    },
+    "normal": {
+      "fg": "#14161b",
+      "bg": "#e0e2ea"
+    },
+    "number": {
+      "fg": "#14161b"
+    },
+    "number.float": {
+      "fg": "#14161b"
+    },
+    "operator": {
+      "fg": "#14161b"
+    },
+    "property": {
+      "fg": "#004c73"
+    },
+    "punctuation.bracket": {
+      "fg": "#14161b"
+    },
+    "punctuation.delimiter": {
+      "fg": "#14161b"
+    },
+    "punctuation.special": {
+      "fg": "#007373"
+    },
+    "string": {
+      "fg": "#005523"
+    },
+    "string.documentation": {
+      "fg": "#005523"
+    },
+    "string.escape": {
+      "fg": "#007373"
+    },
+    "string.regexp": {
+      "fg": "#007373"
+    },
+    "string.special": {
+      "fg": "#007373"
+    },
+    "string.special.path": {
+      "fg": "#007373"
+    },
+    "string.special.symbol": {
+      "fg": "#007373"
+    },
+    "string.special.url": {
+      "underline": true
+    },
+    "tag": {
+      "fg": "#007373"
+    },
+    "tag.attribute": {
+      "fg": "#007373"
+    },
+    "tag.builtin": {
+      "fg": "#007373"
+    },
+    "tag.delimiter": {
+      "fg": "#007373"
+    },
+    "type": {
+      "fg": "#14161b"
+    },
+    "type.builtin": {
+      "fg": "#007373"
+    },
+    "type.definition": {
+      "fg": "#14161b"
+    },
+    "variable": {
+      "fg": "#14161b"
+    },
+    "variable.builtin": {
+      "fg": "#007373"
+    },
+    "variable.member": {
+      "fg": "#14161b"
+    },
+    "variable.parameter": {
+      "fg": "#14161b"
+    },
+    "variable.parameter.builtin": {
+      "fg": "#007373"
+    }
+  }
+}


### PR DESCRIPTION
I tried to run this locally in my blog to test it (use local `autumn`, which was changed to use local `autumnus`, but I wasn't able to get it to work.

Oddly, if I run Autumn.highlight/2, it works. But configuring it through MDEx and running MDEx.to_html does not work.
