### PR TITLE
feat: introduce `header` option in html formatters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+- Add `header` option to HTML formatters for wrapping code blocks with custom HTML elements
+- Add shared `HtmlElement` struct for configuring HTML wrapper elements
+
 ### Improvements
 - Updated parsers: angular, c, cmake, comment, hcl, liquid, llvm, ocaml, perl, vim, vue, yaml
 - Updated queries: cmake, elm, fsharp, html, latex, php, vue

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,16 @@
 # General Guidelines
-
 - Do not add code comments or explanations in the codebase unless explicitly requested
 - Run `cargo test -- --nocapture {test_name}` after changes to ensure all tests pass; Fix any failing tests
 - Run `cargo test` (the whole test suite) only when a lot of files change
 - Run `cargo doc` after doc changes; Fix any warnings or errors in the documentation
 - Run `cargo clippy -- -D warnings` eventually to check for linting issues and fix any warnings
+- Include changes in `CHANGELOG.md` following the Common Changelog format (https://common-changelog.org)
 
 ## Commands
 - `just` is used for common development tasks; use it when a request involves running such commands
 - `cargo run --bin autumn` is the CLI tool for Autumnus
 
 ## Non-standard Directories
-
 - `vendored_parsers/`: Tree-sitter parser C/C++ source code for additional languages
 - `queries/`: Tree-sitter query files for syntax highlighting with inheritance and overwriting support
 - `themes/`: Neovim theme definitions as JSON files
@@ -19,13 +18,11 @@
 - `samples/`: Generated HTML samples for some language/theme combinations
 
 ## Tree-sitter Integration
-
 - Uses both crate-based parsers (in `Cargo.toml`) and vendored parsers (in `vendored_parsers/`)
 - Vendored parsers are necessary for languages not yet available as crates or needing custom modifications
 - Query files support inheritance (`;inherits: language1,language2`) and override system
 
 ## Theme System
-
 - Themes are extracted from Neovim colorschemes using Lua scripts in `themes/`
 - Each theme is a JSON file defining colors for syntax highlighting scopes
 - CSS generation creates stylesheets for HTML linked formatter
@@ -42,7 +39,6 @@
 3. Theme becomes automatically available through the theme system
 
 ## Important Notes
-
 - Features: `elixir` (for Rustler NIF), `dev` (for development tools)
 - Overwrites in `overwrites/` directory can modify or extend query files
 - CSS files are generated and should not be manually edited

--- a/src/bin/autumn/main.rs
+++ b/src/bin/autumn/main.rs
@@ -233,6 +233,7 @@ fn highlight(path: &str, formatter: Option<Formatter>, theme: Option<String>) ->
                         include_highlights: false,
                         theme,
                         highlight_lines: None,
+                        header: None,
                     },
                 },
             );
@@ -248,6 +249,7 @@ fn highlight(path: &str, formatter: Option<Formatter>, theme: Option<String>) ->
                     formatter: FormatterOption::HtmlLinked {
                         pre_class: None,
                         highlight_lines: None,
+                        header: None,
                     },
                 },
             );
@@ -385,6 +387,7 @@ fn highlight_source(
                         include_highlights: false,
                         theme,
                         highlight_lines: None,
+                        header: None,
                     },
                 },
             );
@@ -400,6 +403,7 @@ fn highlight_source(
                     formatter: FormatterOption::HtmlLinked {
                         pre_class: None,
                         highlight_lines: None,
+                        header: None,
                     },
                 },
             );

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -119,6 +119,47 @@ pub use terminal::Terminal;
 
 use crate::languages::Language;
 
+/// Configuration for wrapping the formatted output with custom HTML elements.
+///
+/// This struct allows you to specify opening and closing HTML tags that will wrap
+/// the entire code block. This is useful for adding custom containers, sections,
+/// or other structural elements around the formatted code.
+///
+/// # Examples
+///
+/// Wrapping with a div element:
+/// ```rust
+/// use autumnus::formatter::HtmlElement;
+///
+/// let header = HtmlElement {
+///     open_tag: "<div class=\"code-wrapper\">".to_string(),
+///     close_tag: "</div>".to_string(),
+/// };
+/// ```
+///
+/// Wrapping with a section element with attributes:
+/// ```rust
+/// use autumnus::formatter::HtmlElement;
+///
+/// let header = HtmlElement {
+///     open_tag: "<section class=\"highlight\" data-lang=\"rust\">".to_string(),
+///     close_tag: "</section>".to_string(),
+/// };
+/// ```
+#[derive(Clone, Debug)]
+pub struct HtmlElement {
+    /// The opening HTML tag that will be placed before the formatted code.
+    ///
+    /// This should be a complete HTML opening tag, including any attributes.
+    /// Example: `"<div class=\"wrapper\" id=\"code-block\">"`
+    pub open_tag: String,
+    /// The closing HTML tag that will be placed after the formatted code.
+    ///
+    /// This should be the corresponding closing tag for the opening tag.
+    /// Example: `"</div>"`
+    pub close_tag: String,
+}
+
 pub trait Formatter: Send + Sync {
     fn format(&self, output: &mut dyn Write) -> io::Result<()>;
     fn highlights(&self, output: &mut dyn Write) -> io::Result<()>;
@@ -138,6 +179,7 @@ pub struct HtmlInlineBuilder<'a> {
     italic: bool,
     include_highlights: bool,
     highlight_lines: Option<html_inline::HighlightLines>,
+    header: Option<HtmlElement>,
 }
 
 impl<'a> Default for HtmlInlineBuilder<'a> {
@@ -156,6 +198,7 @@ impl<'a> HtmlInlineBuilder<'a> {
             italic: false,
             include_highlights: false,
             highlight_lines: None,
+            header: None,
         }
     }
 
@@ -194,6 +237,11 @@ impl<'a> HtmlInlineBuilder<'a> {
         self
     }
 
+    pub fn header(mut self, header: HtmlElement) -> Self {
+        self.header = Some(header);
+        self
+    }
+
     pub fn build(self) -> Box<dyn HtmlFormatter + 'a> {
         let source = self.source.unwrap_or_default();
         let lang = self.lang.unwrap_or_default();
@@ -205,6 +253,7 @@ impl<'a> HtmlInlineBuilder<'a> {
             self.italic,
             self.include_highlights,
             self.highlight_lines,
+            self.header,
         ))
     }
 }
@@ -214,6 +263,7 @@ pub struct HtmlLinkedBuilder<'a> {
     lang: Option<Language>,
     pre_class: Option<&'a str>,
     highlight_lines: Option<html_linked::HighlightLines>,
+    header: Option<HtmlElement>,
 }
 
 impl<'a> Default for HtmlLinkedBuilder<'a> {
@@ -229,6 +279,7 @@ impl<'a> HtmlLinkedBuilder<'a> {
             lang: None,
             pre_class: None,
             highlight_lines: None,
+            header: None,
         }
     }
 
@@ -252,6 +303,11 @@ impl<'a> HtmlLinkedBuilder<'a> {
         self
     }
 
+    pub fn header(mut self, header: HtmlElement) -> Self {
+        self.header = Some(header);
+        self
+    }
+
     pub fn build(self) -> Box<dyn HtmlFormatter + 'a> {
         let source = self.source.unwrap_or_default();
         let lang = self.lang.unwrap_or_default();
@@ -260,6 +316,7 @@ impl<'a> HtmlLinkedBuilder<'a> {
             lang,
             self.pre_class,
             self.highlight_lines,
+            self.header,
         ))
     }
 }

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -44,6 +44,7 @@
 //!         italic: false,
 //!         include_highlights: false,
 //!         highlight_lines: None,
+//!         header: None,
 //!     },
 //! };
 //!


### PR DESCRIPTION
Adds a wrapping element to let users embed a header to display metadata like the filename, etc.

Close #11