### PR TITLE
python: Update highlights from upstream

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -1,94 +1,64 @@
-; From tree-sitter-python licensed under MIT License
-; Copyright (c) 2016 Max Brunsfeld
-; Variables
+; Identifier naming conventions
+
 (identifier) @variable
 
-; Reset highlighting in f-string interpolations
-(interpolation) @none
-
-; Identifier naming conventions
-((identifier) @type
-  (#lua-match? @type "^[A-Z].*[a-z]"))
+((identifier) @constructor
+ (#match? @constructor "^[A-Z]"))
 
 ((identifier) @constant
-  (#lua-match? @constant "^[A-Z][A-Z_0-9]*$"))
+ (#match? @constant "^[A-Z][A-Z_]*$"))
 
-((identifier) @constant.builtin
-  (#lua-match? @constant.builtin "^__[a-zA-Z0-9_]*__$"))
+; Function calls
 
-((identifier) @constant.builtin
-  (#any-of? @constant.builtin
-    ; https://docs.python.org/3/library/constants.html
-    "NotImplemented" "Ellipsis" "quit" "exit" "copyright" "credits" "license"))
+(decorator) @function
+(decorator
+  (identifier) @function)
 
-"_" @character.special ; match wildcard
+(call
+  function: (attribute attribute: (identifier) @function.method))
+(call
+  function: (identifier) @function)
 
-((assignment
-  left: (identifier) @type.definition
-  (type
-    (identifier) @_annotation))
-  (#eq? @_annotation "TypeAlias"))
+; Builtin functions
 
-((assignment
-  left: (identifier) @type.definition
-  right: (call
-    function: (identifier) @_func))
-  (#any-of? @_func "TypeVar" "NewType"))
+((call
+  function: (identifier) @function.builtin)
+ (#match?
+   @function.builtin
+   "^(abs|all|any|ascii|bin|bool|breakpoint|bytearray|bytes|callable|chr|classmethod|compile|complex|delattr|dict|dir|divmod|enumerate|eval|exec|filter|float|format|frozenset|getattr|globals|hasattr|hash|help|hex|id|input|int|isinstance|issubclass|iter|len|list|locals|map|max|memoryview|min|next|object|oct|open|ord|pow|print|property|range|repr|reversed|round|set|setattr|slice|sorted|staticmethod|str|sum|super|tuple|type|vars|zip|__import__)$"))
 
 ; Function definitions
+
 (function_definition
   name: (identifier) @function)
 
-(type
-  (identifier) @type)
-
-(type
-  (subscript
-    (identifier) @type)) ; type subscript: Tuple[int]
-
-((call
-  function: (identifier) @_isinstance
-  arguments: (argument_list
-    (_)
-    (identifier) @type))
-  (#eq? @_isinstance "isinstance"))
+(attribute attribute: (identifier) @property)
+(type (identifier) @type)
 
 ; Literals
-(none) @constant.builtin
 
 [
+  (none)
   (true)
   (false)
-] @boolean
-
-(integer) @number
-
-(float) @number.float
-
-(comment) @comment @spell
-
-((module
-  .
-  (comment) @keyword.directive @nospell)
-  (#lua-match? @keyword.directive "^#!/"))
-
-(string) @string
+] @constant.builtin
 
 [
-  (escape_sequence)
-  (escape_interpolation)
-] @string.escape
+  (integer)
+  (float)
+] @number
 
-; doc-strings
-(expression_statement
-  (string
-    (string_content) @spell) @string.documentation)
+(comment) @comment
+(string) @string
+(escape_sequence) @escape
 
-; Tokens
+(interpolation
+  "{" @punctuation.special
+  "}" @punctuation.special) @embedded
+
 [
   "-"
   "-="
-  ":="
   "!="
   "*"
   "**"
@@ -105,6 +75,7 @@
   "^"
   "^="
   "+"
+  "->"
   "+="
   "<"
   "<<"
@@ -112,21 +83,16 @@
   "<="
   "<>"
   "="
+  ":="
   "=="
   ">"
   ">="
   ">>"
   ">>="
-  "@"
-  "@="
   "|"
   "|="
   "~"
-  "->"
-] @operator
-
-; Keywords
-[
+  "@="
   "and"
   "in"
   "is"
@@ -134,311 +100,38 @@
   "or"
   "is not"
   "not in"
-  "del"
-] @keyword.operator
+] @operator
 
 [
-  "def"
-  "lambda"
-] @keyword.function
-
-[
+  "as"
   "assert"
+  "async"
+  "await"
+  "break"
+  "class"
+  "continue"
+  "def"
+  "del"
+  "elif"
+  "else"
+  "except"
   "exec"
+  "finally"
+  "for"
+  "from"
   "global"
+  "if"
+  "import"
+  "lambda"
   "nonlocal"
   "pass"
   "print"
-  "with"
-  "as"
-] @keyword
-
-[
-  "type"
-  "class"
-] @keyword.type
-
-[
-  "async"
-  "await"
-] @keyword.coroutine
-
-[
+  "raise"
   "return"
+  "try"
+  "while"
+  "with"
   "yield"
-] @keyword.return
-
-(yield
-  "from" @keyword.return)
-
-(future_import_statement
-  "from" @keyword.import
-  "__future__" @module.builtin)
-
-(import_from_statement
-  "from" @keyword.import)
-
-"import" @keyword.import
-
-(aliased_import
-  "as" @keyword.import)
-
-(wildcard_import
-  "*" @character.special)
-
-(import_statement
-  name: (dotted_name
-    (identifier) @module))
-
-(import_statement
-  name: (aliased_import
-    name: (dotted_name
-      (identifier) @module)
-    alias: (identifier) @module))
-
-(import_from_statement
-  module_name: (dotted_name
-    (identifier) @module))
-
-(import_from_statement
-  module_name: (relative_import
-    (dotted_name
-      (identifier) @module)))
-
-[
-  "if"
-  "elif"
-  "else"
   "match"
   "case"
-] @keyword.conditional
-
-[
-  "for"
-  "while"
-  "break"
-  "continue"
-] @keyword.repeat
-
-[
-  "try"
-  "except"
-  "raise"
-  "finally"
-] @keyword.exception
-
-(raise_statement
-  "from" @keyword.exception)
-
-(try_statement
-  (else_clause
-    "else" @keyword.exception))
-
-[
-  "("
-  ")"
-  "["
-  "]"
-  "{"
-  "}"
-] @punctuation.bracket
-
-(interpolation
-  "{" @punctuation.special
-  "}" @punctuation.special)
-
-(line_continuation) @punctuation.special
-
-(type_conversion) @function.macro
-
-[
-  ","
-  "."
-  ":"
-  ";"
-  (ellipsis)
-] @punctuation.delimiter
-
-((identifier) @type.builtin
-  (#any-of? @type.builtin
-    ; https://docs.python.org/3/library/exceptions.html
-    "BaseException" "Exception" "ArithmeticError" "BufferError" "LookupError" "AssertionError"
-    "AttributeError" "EOFError" "FloatingPointError" "GeneratorExit" "ImportError"
-    "ModuleNotFoundError" "IndexError" "KeyError" "KeyboardInterrupt" "MemoryError" "NameError"
-    "NotImplementedError" "OSError" "OverflowError" "RecursionError" "ReferenceError" "RuntimeError"
-    "StopIteration" "StopAsyncIteration" "SyntaxError" "IndentationError" "TabError" "SystemError"
-    "SystemExit" "TypeError" "UnboundLocalError" "UnicodeError" "UnicodeEncodeError"
-    "UnicodeDecodeError" "UnicodeTranslateError" "ValueError" "ZeroDivisionError" "EnvironmentError"
-    "IOError" "WindowsError" "BlockingIOError" "ChildProcessError" "ConnectionError"
-    "BrokenPipeError" "ConnectionAbortedError" "ConnectionRefusedError" "ConnectionResetError"
-    "FileExistsError" "FileNotFoundError" "InterruptedError" "IsADirectoryError"
-    "NotADirectoryError" "PermissionError" "ProcessLookupError" "TimeoutError" "Warning"
-    "UserWarning" "DeprecationWarning" "PendingDeprecationWarning" "SyntaxWarning" "RuntimeWarning"
-    "FutureWarning" "ImportWarning" "UnicodeWarning" "BytesWarning" "ResourceWarning"
-    ; https://docs.python.org/3/library/stdtypes.html
-    "bool" "int" "float" "complex" "list" "tuple" "range" "str" "bytes" "bytearray" "memoryview"
-    "set" "frozenset" "dict" "type" "object"))
-
-; Normal parameters
-(parameters
-  (identifier) @variable.parameter)
-
-; Lambda parameters
-(lambda_parameters
-  (identifier) @variable.parameter)
-
-(lambda_parameters
-  (tuple_pattern
-    (identifier) @variable.parameter))
-
-; Default parameters
-(keyword_argument
-  name: (identifier) @variable.parameter)
-
-; Naming parameters on call-site
-(default_parameter
-  name: (identifier) @variable.parameter)
-
-(typed_parameter
-  (identifier) @variable.parameter)
-
-(typed_default_parameter
-  name: (identifier) @variable.parameter)
-
-; Variadic parameters *args, **kwargs
-(parameters
-  (list_splat_pattern ; *args
-    (identifier) @variable.parameter))
-
-(parameters
-  (dictionary_splat_pattern ; **kwargs
-    (identifier) @variable.parameter))
-
-; Typed variadic parameters
-(parameters
-  (typed_parameter
-    (list_splat_pattern ; *args: type
-      (identifier) @variable.parameter)))
-
-(parameters
-  (typed_parameter
-    (dictionary_splat_pattern ; *kwargs: type
-      (identifier) @variable.parameter)))
-
-; Lambda parameters
-(lambda_parameters
-  (list_splat_pattern
-    (identifier) @variable.parameter))
-
-(lambda_parameters
-  (dictionary_splat_pattern
-    (identifier) @variable.parameter))
-
-((identifier) @variable.builtin
-  (#eq? @variable.builtin "self"))
-
-((identifier) @variable.builtin
-  (#eq? @variable.builtin "cls"))
-
-; After @type.builtin bacause builtins (such as `type`) are valid as attribute name
-((attribute
-  attribute: (identifier) @variable.member)
-  (#lua-match? @variable.member "^[%l_].*$"))
-
-; Class definitions
-(class_definition
-  name: (identifier) @type)
-
-(class_definition
-  body: (block
-    (function_definition
-      name: (identifier) @function.method)))
-
-(class_definition
-  superclasses: (argument_list
-    (identifier) @type))
-
-((class_definition
-  body: (block
-    (expression_statement
-      (assignment
-        left: (identifier) @variable.member))))
-  (#lua-match? @variable.member "^[%l_].*$"))
-
-((class_definition
-  body: (block
-    (expression_statement
-      (assignment
-        left: (_
-          (identifier) @variable.member)))))
-  (#lua-match? @variable.member "^[%l_].*$"))
-
-((class_definition
-  (block
-    (function_definition
-      name: (identifier) @constructor)))
-  (#any-of? @constructor "__new__" "__init__"))
-
-; Function calls
-(call
-  function: (identifier) @function.call)
-
-(call
-  function: (attribute
-    attribute: (identifier) @function.method.call))
-
-((call
-  function: (identifier) @constructor)
-  (#lua-match? @constructor "^%u"))
-
-((call
-  function: (attribute
-    attribute: (identifier) @constructor))
-  (#lua-match? @constructor "^%u"))
-
-; Builtin functions
-((call
-  function: (identifier) @function.builtin)
-  (#any-of? @function.builtin
-    "abs" "all" "any" "ascii" "bin" "bool" "breakpoint" "bytearray" "bytes" "callable" "chr"
-    "classmethod" "compile" "complex" "delattr" "dict" "dir" "divmod" "enumerate" "eval" "exec"
-    "filter" "float" "format" "frozenset" "getattr" "globals" "hasattr" "hash" "help" "hex" "id"
-    "input" "int" "isinstance" "issubclass" "iter" "len" "list" "locals" "map" "max" "memoryview"
-    "min" "next" "object" "oct" "open" "ord" "pow" "print" "property" "range" "repr" "reversed"
-    "round" "set" "setattr" "slice" "sorted" "staticmethod" "str" "sum" "super" "tuple" "type"
-    "vars" "zip" "__import__"))
-
-; Regex from the `re` module
-(call
-  function: (attribute
-    object: (identifier) @_re)
-  arguments: (argument_list
-    .
-    (string
-      (string_content) @string.regexp))
-  (#eq? @_re "re"))
-
-; Decorators
-((decorator
-  "@" @attribute)
-  (#set! priority 101))
-
-(decorator
-  (identifier) @attribute)
-
-(decorator
-  (attribute
-    attribute: (identifier) @attribute))
-
-(decorator
-  (call
-    (identifier) @attribute))
-
-(decorator
-  (call
-    (attribute
-      attribute: (identifier) @attribute)))
-
-((decorator
-  (identifier) @attribute.builtin)
-  (#any-of? @attribute.builtin "classmethod" "property" "staticmethod"))
+] @keyword


### PR DESCRIPTION
This new highlight query is much more efficient. When operating on Large files, it performs much better.

queries fetched from https://github.com/tree-sitter/tree-sitter-python/blob/master/queries/highlights.scm

As an example,
https://github.com/home-assistant/core/blob/dev/homeassistant/config_entries.py this file takes 5.6 seconds on main, but 1.4 seconds with this change. (in release mode)

This branch:
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `./target/release/autumn highlight /mnt/media2/code/homeassistant-core/homeassistant/config_entries.py` | 1.371 ± 0.024 | 1.336 | 1.406 | 1.00 |


main:
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `./target/release/autumn highlight /mnt/media2/code/homeassistant-core/homeassistant/config_entries.py` | 5.587 ± 0.116 | 5.397 | 5.732 | 1.00 |