### PR TITLE
feat(Terminal): support default_bg and width options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,6 +1410,7 @@ dependencies = [
  "streaming-iterator",
  "syn 2.0.117",
  "tempfile",
+ "terminal_size",
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "tree-sitter",
@@ -2432,6 +2433,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/lumis-cli/Cargo.toml
+++ b/crates/lumis-cli/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1"
 etcetera = "0.11"
 ureq = "3"
 tempfile = "3"
+terminal_size = "0.4"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/lumis-cli/README.md
+++ b/crates/lumis-cli/README.md
@@ -39,6 +39,12 @@ echo 'fn main() {}' | lumis highlight -l rust
 # Pick a theme
 lumis highlight -t dracula src/main.rs
 
+# Keep an explicit terminal background between styled spans
+lumis highlight --default-bg '#282a36' src/main.rs
+
+# Pad terminal lines to a fixed width
+lumis highlight --default-bg '#282a36' --width 120 src/main.rs
+
 # HTML with inline styles
 lumis highlight -f html-inline -t github_dark src/main.rs
 
@@ -68,6 +74,8 @@ Notes:
 - `lumis highlight [PATH]` reads from stdin when `PATH` is omitted.
 - If the detected language falls back to `plaintext`, the source is printed unchanged.
 - The default theme is `catppuccin_frappe` when a formatter needs a theme and you do not pass `--theme`.
+- `--default-bg` applies only to terminal output and expects a hex color like `#282a36`.
+- `--width` applies only to terminal output. Pass a number or let it default to auto, which uses the current `COLUMNS` value when stdout is a TTY.
 - `html-multi-themes` requires at least one `--themes name:theme_id` entry.
 
 ## Languages

--- a/crates/lumis-cli/src/main.rs
+++ b/crates/lumis-cli/src/main.rs
@@ -14,6 +14,7 @@ use std::fs;
 use std::io::{IsTerminal, Read as _};
 use std::ops::RangeInclusive;
 use std::path::{Path, PathBuf};
+use terminal_size::{terminal_size, Width};
 
 #[derive(Parser)]
 #[command(
@@ -48,7 +49,7 @@ struct Cli {
 enum Commands {
     /// Highlight source code from a file or stdin
     #[command(
-        after_help = "Examples:\n  lumis highlight main.rs\n  lumis highlight -l javascript main.txt\n  lumis highlight -f html-inline -t dracula main.rs\n  lumis highlight -h 1,3-5 lib.rs\n  cat main.rs | lumis highlight -l rust\n  echo 'fn main() {}' | lumis highlight -l rust"
+        after_help = "Examples:\n  lumis highlight main.rs\n  lumis highlight -l javascript main.txt\n  lumis highlight -f html-inline -t dracula main.rs\n  lumis highlight --default-bg '#282a36' --width 120 main.rs\n  lumis highlight -h 1,3-5 lib.rs\n  cat main.rs | lumis highlight -l rust\n  echo 'fn main() {}' | lumis highlight -l rust"
     )]
     Highlight {
         /// File to highlight (reads from stdin if omitted)
@@ -65,6 +66,14 @@ enum Commands {
         /// Theme name, e.g. dracula, github_dark
         #[arg(short = 't', long)]
         theme: Option<String>,
+
+        /// Fallback background color for terminal output, e.g. #282a36
+        #[arg(long)]
+        default_bg: Option<String>,
+
+        /// Terminal render width for background padding. Use a number or 'auto'.
+        #[arg(long)]
+        width: Option<String>,
 
         /// Theme pair as name:theme_id, can be repeated (requires html-multi-themes)
         #[arg(long)]
@@ -202,6 +211,8 @@ fn main() -> Result<()> {
             language,
             formatter,
             theme,
+            default_bg,
+            width,
             themes,
             default_theme,
             css_variable_prefix,
@@ -214,6 +225,8 @@ fn main() -> Result<()> {
                 language,
                 formatter,
                 theme,
+                default_bg,
+                width,
                 themes,
                 default_theme,
                 css_variable_prefix,
@@ -457,6 +470,8 @@ fn do_highlight(
     language: Option<String>,
     formatter: Option<Formatter>,
     theme: Option<String>,
+    default_bg: Option<String>,
+    width: Option<String>,
     themes: Vec<String>,
     default_theme: Option<String>,
     css_variable_prefix: String,
@@ -505,6 +520,8 @@ fn do_highlight(
         lang,
         formatter,
         theme,
+        default_bg,
+        width,
         themes,
         default_theme,
         css_variable_prefix,
@@ -520,6 +537,8 @@ fn render_output(
     lang: Language,
     formatter: Option<Formatter>,
     theme: Option<String>,
+    default_bg: Option<String>,
+    width: Option<String>,
     themes: Vec<String>,
     default_theme: Option<String>,
     css_variable_prefix: String,
@@ -619,7 +638,11 @@ fn render_output(
 
         Formatter::Terminal => {
             let mut builder = lumis_core::formatter::TerminalBuilder::new();
-            builder.language(lang).theme(theme_obj);
+            builder
+                .language(lang)
+                .theme(theme_obj)
+                .default_bg(default_bg)
+                .width(resolve_terminal_width(width.as_deref())?);
 
             let fmt = builder.build().map_err(|e| anyhow::anyhow!("{}", e))?;
             let mut output = Vec::new();
@@ -636,6 +659,40 @@ fn render_output(
     }
 
     Ok(())
+}
+
+fn resolve_terminal_width(width: Option<&str>) -> Result<Option<usize>> {
+    match width {
+        Some("auto") | None => Ok(auto_terminal_width()),
+        Some(raw) => raw.parse::<usize>().map(Some).map_err(|_| {
+            anyhow::anyhow!(
+                "invalid width '{}', expected a positive integer or 'auto'",
+                raw
+            )
+        }),
+    }
+}
+
+fn auto_terminal_width() -> Option<usize> {
+    compute_auto_terminal_width(
+        std::io::stdout().is_terminal(),
+        terminal_size().map(|(Width(width), _)| usize::from(width)),
+        std::env::var("COLUMNS")
+            .ok()
+            .and_then(|value| value.parse().ok()),
+    )
+}
+
+fn compute_auto_terminal_width(
+    stdout_is_terminal: bool,
+    detected_width: Option<usize>,
+    columns_env: Option<usize>,
+) -> Option<usize> {
+    if !stdout_is_terminal {
+        return None;
+    }
+
+    detected_width.or(columns_env)
 }
 
 const EXIT_BAD_ARGUMENTS: i32 = 2;
@@ -843,5 +900,26 @@ end
             event,
             HighlightEvent::Start { language, .. } if language == "heex"
         )));
+    }
+
+    #[test]
+    fn compute_auto_terminal_width_prefers_detected_terminal_width() {
+        assert_eq!(
+            compute_auto_terminal_width(true, Some(120), Some(80)),
+            Some(120)
+        );
+    }
+
+    #[test]
+    fn compute_auto_terminal_width_falls_back_to_columns_env() {
+        assert_eq!(compute_auto_terminal_width(true, None, Some(80)), Some(80));
+    }
+
+    #[test]
+    fn compute_auto_terminal_width_returns_none_when_not_a_tty() {
+        assert_eq!(
+            compute_auto_terminal_width(false, Some(120), Some(80)),
+            None
+        );
     }
 }

--- a/crates/lumis-cli/tests/cli.rs
+++ b/crates/lumis-cli/tests/cli.rs
@@ -198,6 +198,40 @@ fn highlight_source_diff_terminal() {
 }
 
 #[test]
+fn highlight_source_terminal_with_default_background() {
+    cmd()
+        .arg("--data-dir")
+        .arg(fixtures_dir())
+        .args(["highlight", "-l", "diff", "--default-bg", "#282a36"])
+        .write_stdin(DIFF_SNIPPET)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\u{1b}[48;2;40;42;54m"));
+}
+
+#[test]
+fn highlight_source_terminal_with_default_background_and_width() {
+    cmd()
+        .arg("--data-dir")
+        .arg(fixtures_dir())
+        .args([
+            "highlight",
+            "-l",
+            "diff",
+            "--default-bg",
+            "#282a36",
+            "--width",
+            "20",
+        ])
+        .write_stdin("abc\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "\u{1b}[0m\u{1b}[48;2;40;42;54mabc\u{1b}[0m\u{1b}[0m\u{1b}[48;2;40;42;54m                 \u{1b}[0m\n",
+        ));
+}
+
+#[test]
 fn highlight_source_diff_html_inline() {
     cmd()
         .arg("--data-dir")

--- a/crates/lumis-core/src/formatter/terminal.rs
+++ b/crates/lumis-core/src/formatter/terminal.rs
@@ -5,7 +5,7 @@
 use super::{ansi, Formatter};
 use crate::events::HighlightEvent;
 use crate::languages::Language;
-use crate::themes::Theme;
+use crate::themes::{Style, Theme};
 use derive_builder::Builder;
 use std::io::{self, Write};
 
@@ -16,6 +16,8 @@ pub struct Terminal {
     #[builder(setter(custom))]
     language: Language,
     theme: Option<Theme>,
+    default_bg: Option<String>,
+    width: Option<usize>,
 }
 
 impl TerminalBuilder {
@@ -35,8 +37,18 @@ impl TerminalBuilder {
 }
 
 impl Terminal {
-    pub fn new(language: Language, theme: Option<Theme>) -> Self {
-        Self { language, theme }
+    pub fn new(
+        language: Language,
+        theme: Option<Theme>,
+        default_bg: Option<String>,
+        width: Option<usize>,
+    ) -> Self {
+        Self {
+            language,
+            theme,
+            default_bg,
+            width,
+        }
     }
 }
 
@@ -45,6 +57,8 @@ impl Default for Terminal {
         Self {
             language: Language::PlainText,
             theme: None,
+            default_bg: None,
+            width: None,
         }
     }
 }
@@ -58,6 +72,7 @@ impl Formatter for Terminal {
     ) -> io::Result<()> {
         let source_bytes = source.as_bytes();
         let mut scope_stack: Vec<(usize, String)> = Vec::new();
+        let mut line_width = 0usize;
 
         for event in events {
             match event {
@@ -87,10 +102,33 @@ impl Formatter for Terminal {
                             .or_else(|| theme.get_style(scope))
                     });
 
-                    if let Some(style) = styled {
-                        write!(output, "{}", ansi::paint(text, style))?;
-                    } else {
-                        write!(output, "{}", text)?;
+                    for segment in text.split_inclusive('\n') {
+                        let has_newline = segment.ends_with('\n');
+                        let content = if has_newline {
+                            &segment[..segment.len() - 1]
+                        } else {
+                            segment
+                        };
+
+                        if !content.is_empty() {
+                            write!(
+                                output,
+                                "{}",
+                                paint_with_default_bg(content, styled, self.default_bg.as_deref())
+                            )?;
+                            line_width += display_width(content);
+                        }
+
+                        if has_newline {
+                            write_line_padding(
+                                output,
+                                self.default_bg.as_deref(),
+                                self.width,
+                                line_width,
+                            )?;
+                            writeln!(output)?;
+                            line_width = 0;
+                        }
                     }
                 }
                 HighlightEvent::Start {
@@ -103,6 +141,157 @@ impl Formatter for Terminal {
             }
         }
 
+        if !source.ends_with('\n') {
+            write_line_padding(output, self.default_bg.as_deref(), self.width, line_width)?;
+        }
+
         Ok(())
+    }
+}
+
+fn paint_with_default_bg(text: &str, style: Option<&Style>, default_bg: Option<&str>) -> String {
+    match (style, default_bg) {
+        (Some(style), Some(default_bg)) if style.bg.is_none() => {
+            let mut style = style.clone();
+            style.bg = Some(default_bg.to_string());
+            ansi::paint(text, &style)
+        }
+        (Some(style), _) => ansi::paint(text, style),
+        (None, Some(default_bg)) => ansi::paint(
+            text,
+            &Style {
+                bg: Some(default_bg.to_string()),
+                ..Default::default()
+            },
+        ),
+        (None, None) => text.to_string(),
+    }
+}
+
+fn write_line_padding(
+    output: &mut dyn Write,
+    default_bg: Option<&str>,
+    width: Option<usize>,
+    line_width: usize,
+) -> io::Result<()> {
+    let Some(default_bg) = default_bg else {
+        return Ok(());
+    };
+    let Some(width) = width else {
+        return Ok(());
+    };
+
+    if line_width >= width {
+        return Ok(());
+    }
+
+    let padding = " ".repeat(width - line_width);
+    write!(
+        output,
+        "{}",
+        paint_with_default_bg(&padding, None, Some(default_bg))
+    )
+}
+
+fn display_width(text: &str) -> usize {
+    text.chars()
+        .map(|ch| match ch {
+            '\t' => 4,
+            _ => 1,
+        })
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn paint_with_default_bg_applies_background_to_unstyled_text() {
+        let painted = paint_with_default_bg("abc", None, Some("#282a36"));
+
+        assert_eq!(painted, "\u{1b}[0m\u{1b}[48;2;40;42;54mabc\u{1b}[0m");
+    }
+
+    #[test]
+    fn paint_with_default_bg_uses_fallback_when_style_has_no_background() {
+        let style = Style {
+            fg: Some("#8be9fd".to_string()),
+            bold: true,
+            ..Default::default()
+        };
+
+        let painted = paint_with_default_bg("fn", Some(&style), Some("#282a36"));
+
+        assert!(painted.contains("\u{1b}[38;2;139;233;253m"));
+        assert!(painted.contains("\u{1b}[48;2;40;42;54m"));
+        assert!(painted.contains("\u{1b}[1m"));
+    }
+
+    #[test]
+    fn paint_with_default_bg_preserves_explicit_style_background() {
+        let style = Style {
+            fg: Some("#8be9fd".to_string()),
+            bg: Some("#ff0000".to_string()),
+            ..Default::default()
+        };
+
+        let painted = paint_with_default_bg("fn", Some(&style), Some("#282a36"));
+
+        assert!(painted.contains("\u{1b}[48;2;255;0;0m"));
+        assert!(!painted.contains("\u{1b}[48;2;40;42;54m"));
+    }
+
+    #[test]
+    fn paint_with_default_bg_resets_around_newlines() {
+        let style = Style {
+            fg: Some("#8be9fd".to_string()),
+            ..Default::default()
+        };
+
+        let painted = paint_with_default_bg("a\nb", Some(&style), Some("#282a36"));
+
+        assert_eq!(
+            painted,
+            "\u{1b}[0m\u{1b}[38;2;139;233;253m\u{1b}[48;2;40;42;54ma\u{1b}[0m\n\u{1b}[38;2;139;233;253m\u{1b}[48;2;40;42;54mb\u{1b}[0m"
+        );
+    }
+
+    #[test]
+    fn render_pads_lines_to_width_with_default_background() {
+        let formatter = Terminal::new(
+            Language::PlainText,
+            None,
+            Some("#282a36".to_string()),
+            Some(5),
+        );
+        let events = [HighlightEvent::Source { start: 0, end: 2 }];
+        let mut output = Vec::new();
+
+        formatter.render("hi", &events, &mut output).unwrap();
+
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            "\u{1b}[0m\u{1b}[48;2;40;42;54mhi\u{1b}[0m\u{1b}[0m\u{1b}[48;2;40;42;54m   \u{1b}[0m"
+        );
+    }
+
+    #[test]
+    fn render_pads_each_line_before_newline() {
+        let formatter = Terminal::new(
+            Language::PlainText,
+            None,
+            Some("#282a36".to_string()),
+            Some(4),
+        );
+        let events = [HighlightEvent::Source { start: 0, end: 3 }];
+        let mut output = Vec::new();
+
+        formatter.render("a\nb", &events, &mut output).unwrap();
+
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            "\u{1b}[0m\u{1b}[48;2;40;42;54ma\u{1b}[0m\u{1b}[0m\u{1b}[48;2;40;42;54m   \u{1b}[0m\n\u{1b}[0m\u{1b}[48;2;40;42;54mb\u{1b}[0m\u{1b}[0m\u{1b}[48;2;40;42;54m   \u{1b}[0m"
+        );
     }
 }

--- a/crates/lumis/src/formatter/terminal.rs
+++ b/crates/lumis/src/formatter/terminal.rs
@@ -52,6 +52,8 @@ pub struct Terminal {
     #[builder(setter(custom))]
     language: Language,
     theme: Option<Theme>,
+    default_bg: Option<String>,
+    width: Option<usize>,
 }
 
 impl TerminalBuilder {
@@ -71,8 +73,18 @@ impl TerminalBuilder {
 }
 
 impl Terminal {
-    pub fn new(language: Language, theme: Option<Theme>) -> Self {
-        Self { language, theme }
+    pub fn new(
+        language: Language,
+        theme: Option<Theme>,
+        default_bg: Option<String>,
+        width: Option<usize>,
+    ) -> Self {
+        Self {
+            language,
+            theme,
+            default_bg,
+            width,
+        }
     }
 }
 
@@ -81,6 +93,8 @@ impl Default for Terminal {
         Self {
             language: Language::PlainText,
             theme: None,
+            default_bg: None,
+            width: None,
         }
     }
 }
@@ -90,8 +104,12 @@ impl Formatter for Terminal {
         let events =
             highlight::highlight_events(source, self.language).map_err(io::Error::other)?;
 
-        let core_formatter =
-            lumis_core::formatter::terminal::Terminal::new(self.language, self.theme.clone());
+        let core_formatter = lumis_core::formatter::terminal::Terminal::new(
+            self.language,
+            self.theme.clone(),
+            self.default_bg.clone(),
+            self.width,
+        );
         core_formatter.render(source, &events, output)
     }
 }
@@ -103,7 +121,7 @@ mod tests {
     #[test]
     fn test_no_attrs() {
         let code = "@lang :rust";
-        let formatter = Terminal::new(Language::Elixir, None);
+        let formatter = Terminal::new(Language::Elixir, None, None, None);
         let mut buffer = Vec::new();
         formatter.format(code, &mut buffer).unwrap();
         let result = String::from_utf8_lossy(&buffer);

--- a/docs/content/usage/formatters/terminal.mdx
+++ b/docs/content/usage/formatters/terminal.mdx
@@ -20,11 +20,11 @@ ANSI escape codes for shell output.
 
 | Runtime | Options |
 | --- | --- |
-| Rust | `language`, `theme` |
-| Elixir | `language`, `theme` |
+| Rust | `language`, `theme`, `default_bg`, `width` |
+| Elixir | `language`, `theme`, `default_bg`, `width` |
 | JavaScript | `language`, `theme` |
 | Java | `withLang()`, `withTheme()`, `withFormatter(Formatter.TERMINAL)` |
-| CLI | default formatter, `--theme` |
+| CLI | default formatter, `--theme`, `--default-bg`, `--width` |
 
 ## Example
 
@@ -52,6 +52,8 @@ let ansi = highlight(
     TerminalBuilder::new()
         .language(Language::Rust)
         .theme(Some(themes::get("dracula").unwrap()))
+        .default_bg(Some("#282a36".to_string()))
+        .width(Some(120))
         .build()
         .unwrap(),
 );
@@ -65,7 +67,7 @@ println!("{}", ansi);
 ```elixir
 Lumis.highlight!(
   "fn main() {}",
-  formatter: {:terminal, language: "rust", theme: "dracula"}
+  formatter: {:terminal, language: "rust", theme: "dracula", default_bg: "#282a36", width: 120}
 )
 ```
 
@@ -98,6 +100,8 @@ lumis.close();
 ```bash
 lumis highlight main.rs --theme dracula
 # same as: lumis highlight main.rs --formatter terminal --theme dracula
+lumis highlight main.rs --theme dracula --default-bg '#282a36'
+lumis highlight main.rs --theme dracula --default-bg '#282a36' --width 120
 ```
 
   </TabItem>
@@ -113,6 +117,8 @@ Terminal output is plain text wrapped in ANSI escape sequences:
 
 - the source stays as terminal text, not HTML
 - ANSI escape sequences set foreground color and text styles
+- `default_bg` / `--default-bg` fills in the background only where the token style does not already provide one
+- `width` / `--width` pads each rendered line to the requested width; in the CLI, `auto` uses the current terminal width when available
 - `\x1b[0m` resets formatting between styled segments
 
 ## When to use it

--- a/packages/elixir/lumis/lib/lumis.ex
+++ b/packages/elixir/lumis/lib/lumis.ex
@@ -138,6 +138,8 @@ defmodule Lumis do
 
       - `:language` (`t:language/0` - default: `nil`) - the language used by the formatter. When omitted, Lumis tries to auto-detect it from the source.
       - `:theme` (`t:theme/0` - default: `nil`) - the theme to apply styles on the highlighted source code.
+      - `:default_bg` (`t:String.t/0` - default: `nil`) - a fallback background color applied between styled spans and on unstyled text.
+      - `:width` (`pos_integer() | nil` - default: `nil`) - pad each rendered terminal line to the given width. This is most useful with `:default_bg`.
 
   * `bbcode_scoped`:
 
@@ -262,7 +264,9 @@ defmodule Lumis do
           | {:terminal,
              [
                language: language(),
-               theme: theme()
+               theme: theme(),
+               default_bg: String.t() | nil,
+               width: pos_integer() | nil
              ]}
           | :bbcode_scoped
           | {:bbcode_scoped, [language: language()]}
@@ -476,9 +480,9 @@ defmodule Lumis do
   end
 
   def formatter_type({:terminal, options}) when is_list(options) do
-    case Keyword.keys(options) -- [:language, :theme] do
+    case Keyword.keys(options) -- [:language, :theme, :default_bg, :width] do
       [] ->
-        default_opts = [language: nil, theme: @default_theme]
+        default_opts = [language: nil, theme: @default_theme, default_bg: nil, width: nil]
         opts = Keyword.merge(default_opts, options)
         {:ok, {:terminal, opts}}
 
@@ -973,7 +977,7 @@ defmodule Lumis do
 
   defp convert_formatter_for_nif(:terminal, opts) do
     opts = convert_theme_for_nif(opts)
-    {:terminal, Map.take(opts, [:theme])}
+    {:terminal, Map.take(opts, [:theme, :default_bg, :width])}
   end
 
   defp convert_formatter_for_nif(:bbcode_scoped, _opts) do

--- a/packages/elixir/lumis/native/lumis_nif/src/elixir.rs
+++ b/packages/elixir/lumis/native/lumis_nif/src/elixir.rs
@@ -40,6 +40,8 @@ pub enum ExFormatterOption {
     },
     Terminal {
         theme: Option<ThemeOrString>,
+        default_bg: Option<String>,
+        width: Option<usize>,
     },
     BbcodeScoped {},
 }
@@ -203,12 +205,18 @@ impl ExFormatterOption {
 
                 Ok(Box::new(formatter))
             }
-            ExFormatterOption::Terminal { theme } => {
+            ExFormatterOption::Terminal {
+                theme,
+                default_bg,
+                width,
+            } => {
                 let theme = theme.and_then(resolve_theme);
 
                 let formatter = TerminalBuilder::new()
                     .language(language)
                     .theme(theme)
+                    .default_bg(default_bg)
+                    .width(width)
                     .build()
                     .map_err(|e| format!("Terminal builder error: {:?}", e))?;
 

--- a/packages/elixir/lumis/test/lumis_test.exs
+++ b/packages/elixir/lumis/test/lumis_test.exs
@@ -166,7 +166,7 @@ defmodule Lumis.LumisTest do
   describe "formatter_type: :terminal" do
     test "default opts" do
       assert Lumis.formatter_type(:terminal) ==
-               {:ok, {:terminal, [language: nil, theme: "onedark"]}}
+               {:ok, {:terminal, [language: nil, theme: "onedark", default_bg: nil, width: nil]}}
     end
   end
 
@@ -236,6 +236,20 @@ defmodule Lumis.LumisTest do
                Lumis.formatter_type({:terminal, [language: "rust"]})
 
       assert Keyword.get(opts, :language) == "rust"
+    end
+
+    test "formatter_type preserves default_bg for terminal" do
+      assert {:ok, {:terminal, opts}} =
+               Lumis.formatter_type({:terminal, [default_bg: "#282a36"]})
+
+      assert Keyword.get(opts, :default_bg) == "#282a36"
+    end
+
+    test "formatter_type preserves width for terminal" do
+      assert {:ok, {:terminal, opts}} =
+               Lumis.formatter_type({:terminal, [width: 120]})
+
+      assert Keyword.get(opts, :width) == 120
     end
 
     test "formatter_type preserves language for bbcode_scoped" do
@@ -1274,6 +1288,30 @@ defmodule Lumis.LumisTest do
 
       assert %{formatter: {:terminal, %{theme: {:string, "github_light"}}}} =
                Lumis.rust_options!(options)
+    end
+
+    test "converts terminal formatter default background" do
+      options =
+        Lumis.validate_options!(
+          formatter: {:terminal, theme: "github_light", default_bg: "#ffffff"}
+        )
+
+      assert %{
+               formatter: {:terminal, %{theme: {:string, "github_light"}, default_bg: "#ffffff"}}
+             } = Lumis.rust_options!(options)
+    end
+
+    test "converts terminal formatter width" do
+      options =
+        Lumis.validate_options!(
+          formatter: {:terminal, theme: "github_light", default_bg: "#ffffff", width: 120}
+        )
+
+      assert %{
+               formatter:
+                 {:terminal,
+                  %{theme: {:string, "github_light"}, default_bg: "#ffffff", width: 120}}
+             } = Lumis.rust_options!(options)
     end
 
     test "converts bbcode_scoped formatter" do


### PR DESCRIPTION
The default_bg and width options have been added for formatting. The CLI and Elixir bindings have been updated to support this. This allows outputting the format with a specific background color instead of depending on the terminal default.

The terminal_size crate is used to determine the width, falling back to the `COLUMNS` environment variable if available. This is used if no width is set, or the width is set to auto, otherwise the provided width will be used.