### PR TITLE
Add StyleOverride trait and rainbow brackets for terminal formatter

### DIFF
--- a/crates/lumis-cli/src/main.rs
+++ b/crates/lumis-cli/src/main.rs
@@ -650,23 +650,17 @@ fn render_output(
             let mut builder = lumis_core::formatter::TerminalBuilder::new();
             builder
                 .language(lang)
-                .theme(theme_obj)
+                .theme(theme_obj.clone())
                 .background(parse_terminal_background(background.as_deref()))
                 .width(resolve_terminal_width(width.as_deref())?);
 
             let mut fmt = builder.build().map_err(|e| anyhow::anyhow!("{}", e))?;
 
             if rainbow_brackets {
-                fmt = fmt.with_style_override(std::sync::Arc::new(
-                    lumis_core::formatter::RainbowBrackets::new(vec![
-                        "#e06c75".into(),
-                        "#61afef".into(),
-                        "#98c379".into(),
-                        "#e5c07b".into(),
-                        "#c678dd".into(),
-                        "#56b6c2".into(),
-                    ]),
-                ));
+                fmt = fmt.with_style_override(
+                    lumis_core::formatter::RainbowBrackets::from_theme(theme_obj.as_ref())
+                        .into_override(),
+                );
             }
 
             let mut output = Vec::new();

--- a/crates/lumis-cli/src/main.rs
+++ b/crates/lumis-cli/src/main.rs
@@ -91,6 +91,10 @@ enum Commands {
         /// Lines to highlight, e.g. "1,3-5,10"
         #[arg(short = 'h', long)]
         highlight_lines: Option<String>,
+
+        /// Color nested brackets by depth (terminal formatter only)
+        #[arg(long)]
+        rainbow_brackets: bool,
     },
 
     /// Manage languages
@@ -218,6 +222,7 @@ fn main() -> Result<()> {
             default_theme,
             css_variable_prefix,
             highlight_lines,
+            rainbow_brackets,
         } => {
             let reg = registry::Registry::new(data_dir)?;
             do_highlight(
@@ -232,6 +237,7 @@ fn main() -> Result<()> {
                 default_theme,
                 css_variable_prefix,
                 highlight_lines,
+                rainbow_brackets,
             )
         }
         Commands::Languages { command } => match command {
@@ -477,6 +483,7 @@ fn do_highlight(
     default_theme: Option<String>,
     css_variable_prefix: String,
     highlight_lines: Option<String>,
+    rainbow_brackets: bool,
 ) -> Result<()> {
     let (source, lang) = if let Some(path) = path {
         let bytes = read_or_die(Path::new(&path));
@@ -527,6 +534,7 @@ fn do_highlight(
         default_theme,
         css_variable_prefix,
         parsed_highlight_lines,
+        rainbow_brackets,
     )
 }
 
@@ -544,6 +552,7 @@ fn render_output(
     default_theme: Option<String>,
     css_variable_prefix: String,
     highlight_lines: Option<Vec<RangeInclusive<usize>>>,
+    rainbow_brackets: bool,
 ) -> Result<()> {
     let theme_obj = resolve_theme(theme, Some(reg.data_dir()));
 
@@ -645,7 +654,21 @@ fn render_output(
                 .background(parse_terminal_background(background.as_deref()))
                 .width(resolve_terminal_width(width.as_deref())?);
 
-            let fmt = builder.build().map_err(|e| anyhow::anyhow!("{}", e))?;
+            let mut fmt = builder.build().map_err(|e| anyhow::anyhow!("{}", e))?;
+
+            if rainbow_brackets {
+                fmt = fmt.with_style_override(std::sync::Arc::new(
+                    lumis_core::formatter::RainbowBrackets::new(vec![
+                        "#e06c75".into(),
+                        "#61afef".into(),
+                        "#98c379".into(),
+                        "#e5c07b".into(),
+                        "#c678dd".into(),
+                        "#56b6c2".into(),
+                    ]),
+                ));
+            }
+
             let mut output = Vec::new();
             fmt.render(source, events, &mut output)?;
             print!("{}", String::from_utf8(output)?);

--- a/crates/lumis-cli/themes/extract_theme.lua
+++ b/crates/lumis-cli/themes/extract_theme.lua
@@ -15,7 +15,7 @@ local function plugin_dir_name(repo_url)
 	if not repo then
 		return "unknown"
 	end
-	if owner and colliding_repo_names[repo] then
+	if owner and colliding_repo_names[string.lower(repo)] then
 		return owner .. "-" .. repo
 	end
 	return repo
@@ -33,6 +33,16 @@ local regular_groups = {
 	"Normal",
 	"Comment",
 	"CursorLine",
+}
+
+local rainbow_delimiter_groups = {
+	"RainbowDelimiterRed",
+	"RainbowDelimiterYellow",
+	"RainbowDelimiterBlue",
+	"RainbowDelimiterOrange",
+	"RainbowDelimiterGreen",
+	"RainbowDelimiterViolet",
+	"RainbowDelimiterCyan",
 }
 
 local treesitter_groups = {
@@ -328,6 +338,10 @@ local function extract_colorscheme_colors(theme)
 		table.insert(all_groups, group)
 	end
 
+	for _, group in ipairs(rainbow_delimiter_groups) do
+		table.insert(all_groups, group)
+	end
+
 	for _, group in ipairs(treesitter_groups) do
 		table.insert(all_groups, "@" .. group)
 	end
@@ -343,6 +357,9 @@ local function extract_colorscheme_colors(theme)
 			local key = string.lower(string.gsub(group, "@", ""))
 			if key == "cursorline" then
 				key = "highlighted"
+			elseif string.sub(group, 1, string.len("RainbowDelimiter")) == "RainbowDelimiter" then
+				key = string.gsub(group, "RainbowDelimiter", "rainbow.delimiter.")
+				key = string.lower(key)
 			end
 			highlights[key] = style
 		end
@@ -442,15 +459,17 @@ local repo_names = {}
 for _, theme_def in ipairs(themes) do
 	local _, repo = parse_repo_parts(theme_def.url)
 	if repo then
-		repo_names[repo] = repo_names[repo] or {}
-		repo_names[repo][theme_def.url] = true
+		local key = string.lower(repo)
+		repo_names[key] = repo_names[key] or {}
+		repo_names[key][theme_def.url] = true
 	end
 	if theme_def.dependencies then
 		for _, dep_url in ipairs(theme_def.dependencies) do
 			local _, dep_repo = parse_repo_parts(dep_url)
 			if dep_repo then
-				repo_names[dep_repo] = repo_names[dep_repo] or {}
-				repo_names[dep_repo][dep_url] = true
+				local key = string.lower(dep_repo)
+				repo_names[key] = repo_names[key] or {}
+				repo_names[key][dep_url] = true
 			end
 		end
 	end

--- a/crates/lumis-core/src/formatter/mod.rs
+++ b/crates/lumis-core/src/formatter/mod.rs
@@ -12,6 +12,7 @@
 //! - [`bbcode`] - BBCode scoped output using highlight scope names as tags
 
 use crate::events::HighlightEvent;
+use crate::themes::Style;
 use std::io::{self, Write};
 
 pub mod ansi;
@@ -26,6 +27,9 @@ pub use html_multi_themes::{HtmlMultiThemes, HtmlMultiThemesBuilder};
 pub mod html_linked;
 pub use html_linked::{HtmlLinked, HtmlLinkedBuilder};
 
+pub mod rainbow_brackets;
+pub use rainbow_brackets::RainbowBrackets;
+
 pub mod terminal;
 pub use terminal::{Background as TerminalBackground, Terminal, TerminalBuilder};
 
@@ -39,6 +43,47 @@ pub struct HtmlElement {
     pub open_tag: String,
     /// The closing HTML tag that will be placed after the formatted code.
     pub close_tag: String,
+}
+
+/// Trait for overriding the style of tokens during formatting.
+///
+/// Implementations receive the resolved theme style for each token and can
+/// return a modified style. This enables features like rainbow brackets without
+/// changing the formatter itself.
+///
+/// The `state` parameter is a `usize` that the override can use to track
+/// information across tokens (e.g., bracket nesting depth). It starts at `0`
+/// and is passed mutably to each call.
+///
+/// # Example
+///
+/// ```rust
+/// use lumis_core::formatter::StyleOverride;
+/// use lumis_core::themes::Style;
+///
+/// struct RainbowBrackets;
+///
+/// impl StyleOverride for RainbowBrackets {
+///     fn override_style(&self, text: &str, scope: &str, base: &Style, state: &mut usize) -> Style {
+///         if scope.starts_with("punctuation.bracket") {
+///             // ... apply rainbow color based on *state ...
+///             Style { fg: Some("#e06c75".to_string()), ..base.clone() }
+///         } else {
+///             base.clone()
+///         }
+///     }
+/// }
+/// ```
+pub trait StyleOverride: Send + Sync + std::fmt::Debug {
+    /// Return the style to use for this token.
+    ///
+    /// # Arguments
+    ///
+    /// * `text` - The source text of the token
+    /// * `scope` - The highlight scope name (e.g., `"punctuation.bracket"`)
+    /// * `base` - The style resolved from the theme
+    /// * `state` - Mutable state that persists across tokens within a single `render` call
+    fn override_style(&self, text: &str, scope: &str, base: &Style, state: &mut usize) -> Style;
 }
 
 /// Trait for implementing custom syntax highlighting formatters.

--- a/crates/lumis-core/src/formatter/rainbow_brackets.rs
+++ b/crates/lumis-core/src/formatter/rainbow_brackets.rs
@@ -1,0 +1,73 @@
+//! Rainbow bracket [`StyleOverride`] implementation.
+//!
+//! Colors nested bracket pairs with a cycling palette so that matching
+//! delimiters are visually distinct at a glance.
+//!
+//! # Example
+//!
+//! ```rust
+//! use lumis_core::formatter::StyleOverride;
+//! use lumis_core::formatter::RainbowBrackets;
+//!
+//! let colors = vec!["#e06c75".into(), "#61afef".into(), "#98c379".into()];
+//! let rb = RainbowBrackets::new(colors);
+//! ```
+
+use crate::themes::Style;
+use std::sync::Arc;
+
+use super::StyleOverride;
+
+const CLOSE_BRACKETS: &[char] = &['}', ']', ')', '>'];
+
+/// A [`StyleOverride`] that colors bracket characters with a cycling
+/// palette based on nesting depth.
+#[derive(Clone, Debug)]
+pub struct RainbowBrackets {
+    colors: Vec<String>,
+}
+
+impl RainbowBrackets {
+    /// Create a new override with the given color palette.
+    ///
+    /// Colors cycle by nesting depth: depth 0 gets `colors[0]`,
+    /// depth 1 gets `colors[1]`, and so on, wrapping around.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `colors` is empty.
+    pub fn new(colors: Vec<String>) -> Self {
+        assert!(
+            !colors.is_empty(),
+            "RainbowBrackets requires at least one color"
+        );
+        Self { colors }
+    }
+
+    /// Convenience constructor that wraps in `Arc<dyn StyleOverride>`.
+    pub fn into_override(self) -> Arc<dyn StyleOverride> {
+        Arc::new(self)
+    }
+}
+
+impl StyleOverride for RainbowBrackets {
+    fn override_style(&self, text: &str, scope: &str, base: &Style, state: &mut usize) -> Style {
+        if !scope.starts_with("punctuation.bracket") {
+            return base.clone();
+        }
+
+        let color_idx = if text.starts_with(|c: char| CLOSE_BRACKETS.contains(&c)) {
+            *state = state.saturating_sub(1);
+            *state % self.colors.len()
+        } else {
+            let idx = *state % self.colors.len();
+            *state = state.saturating_add(1);
+            idx
+        };
+
+        Style {
+            fg: Some(self.colors[color_idx].clone()),
+            ..base.clone()
+        }
+    }
+}

--- a/crates/lumis-core/src/formatter/rainbow_brackets.rs
+++ b/crates/lumis-core/src/formatter/rainbow_brackets.rs
@@ -13,12 +13,24 @@
 //! let rb = RainbowBrackets::new(colors);
 //! ```
 
-use crate::themes::Style;
+use crate::themes::{Style, Theme};
 use std::sync::Arc;
 
 use super::StyleOverride;
 
 const CLOSE_BRACKETS: &[char] = &['}', ']', ')', '>'];
+const FALLBACK_COLORS: &[&str] = &[
+    "#e06c75", "#e5c07b", "#61afef", "#d19a66", "#98c379", "#c678dd", "#56b6c2",
+];
+const THEME_COLOR_SCOPES: &[&str] = &[
+    "rainbow.delimiter.red",
+    "rainbow.delimiter.yellow",
+    "rainbow.delimiter.blue",
+    "rainbow.delimiter.orange",
+    "rainbow.delimiter.green",
+    "rainbow.delimiter.violet",
+    "rainbow.delimiter.cyan",
+];
 
 /// A [`StyleOverride`] that colors bracket characters with a cycling
 /// palette based on nesting depth.
@@ -41,6 +53,25 @@ impl RainbowBrackets {
             !colors.is_empty(),
             "RainbowBrackets requires at least one color"
         );
+        Self { colors }
+    }
+
+    /// Create an override from the standard `RainbowDelimiter*` theme groups.
+    ///
+    /// Missing theme colors fall back to a built-in palette using the standard
+    /// red, yellow, blue, orange, green, violet, cyan order.
+    pub fn from_theme(theme: Option<&Theme>) -> Self {
+        let colors = THEME_COLOR_SCOPES
+            .iter()
+            .zip(FALLBACK_COLORS)
+            .map(|(scope, fallback)| {
+                theme
+                    .and_then(|theme| theme.get_style(scope))
+                    .and_then(|style| style.fg.clone())
+                    .unwrap_or_else(|| (*fallback).to_string())
+            })
+            .collect();
+
         Self { colors }
     }
 
@@ -69,5 +100,50 @@ impl StyleOverride for RainbowBrackets {
             fg: Some(self.colors[color_idx].clone()),
             ..base.clone()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::themes::Appearance;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn from_theme_uses_standard_rainbow_delimiter_groups() {
+        let mut highlights = BTreeMap::new();
+        highlights.insert(
+            "rainbow.delimiter.red".to_string(),
+            Style {
+                fg: Some("#ff0000".to_string()),
+                ..Style::default()
+            },
+        );
+        highlights.insert(
+            "rainbow.delimiter.yellow".to_string(),
+            Style {
+                fg: Some("#ffff00".to_string()),
+                ..Style::default()
+            },
+        );
+
+        let theme = Theme {
+            name: "test".to_string(),
+            appearance: Appearance::Dark,
+            revision: "test".to_string(),
+            highlights,
+        };
+        let rainbow = RainbowBrackets::from_theme(Some(&theme));
+
+        assert_eq!(rainbow.colors[0], "#ff0000");
+        assert_eq!(rainbow.colors[1], "#ffff00");
+        assert_eq!(rainbow.colors[2], "#61afef");
+    }
+
+    #[test]
+    fn from_theme_uses_full_fallback_palette_without_theme() {
+        let rainbow = RainbowBrackets::from_theme(None);
+
+        assert_eq!(rainbow.colors, FALLBACK_COLORS);
     }
 }

--- a/crates/lumis-core/src/formatter/terminal.rs
+++ b/crates/lumis-core/src/formatter/terminal.rs
@@ -2,12 +2,13 @@
 //!
 //! Works with pre-computed highlight events from any source.
 
-use super::{ansi, Formatter};
+use super::{ansi, Formatter, StyleOverride};
 use crate::events::HighlightEvent;
 use crate::languages::Language;
 use crate::themes::{Style, Theme};
 use derive_builder::Builder;
 use std::io::{self, Write};
+use std::sync::Arc;
 
 /// Background fill behavior for terminal output.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -30,6 +31,7 @@ pub struct Terminal {
     theme: Option<Theme>,
     background: Background,
     width: Option<usize>,
+    style_override: Option<Arc<dyn StyleOverride>>,
 }
 
 impl TerminalBuilder {
@@ -60,7 +62,13 @@ impl Terminal {
             theme,
             background,
             width,
+            style_override: None,
         }
+    }
+
+    pub fn with_style_override(mut self, style_override: Arc<dyn StyleOverride>) -> Self {
+        self.style_override = Some(style_override);
+        self
     }
 
     fn fallback_bg(&self) -> Option<&str> {
@@ -79,6 +87,7 @@ impl Default for Terminal {
             theme: None,
             background: Background::Inherit,
             width: None,
+            style_override: None,
         }
     }
 }
@@ -94,6 +103,7 @@ impl Formatter for Terminal {
         let mut scope_stack: Vec<(usize, String)> = Vec::new();
         let mut line_width = 0usize;
         let fallback_bg = self.fallback_bg();
+        let mut override_state: usize = 0;
 
         for event in events {
             match event {
@@ -111,20 +121,40 @@ impl Formatter for Terminal {
                     }
                     let text = std::str::from_utf8(&source_bytes[*start..*end])
                         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-                    let styled = scope_stack.last().and_then(|(scope_index, language)| {
-                        let theme = self.theme.as_ref()?;
-                        let scope = crate::highlights::HIGHLIGHT_NAMES
-                            .get(*scope_index)
-                            .copied()
-                            .unwrap_or("");
-                        let specialized = format!("{}.{}", scope, language);
-                        theme
-                            .get_style(&specialized)
-                            .or_else(|| theme.get_style(scope))
-                    });
+                    let (styled, scope_name) = scope_stack
+                        .last()
+                        .map(|(scope_index, language)| {
+                            let scope = crate::highlights::HIGHLIGHT_NAMES
+                                .get(*scope_index)
+                                .copied()
+                                .unwrap_or("");
+                            let specialized = format!("{}.{}", scope, language);
+                            let style = self.theme.as_ref().and_then(|t| {
+                                t.get_style(&specialized).or_else(|| t.get_style(scope))
+                            });
+                            (style, scope)
+                        })
+                        .unwrap_or((None, ""));
+
+                    let styled = styled.cloned();
+
+                    let styled = match (&self.style_override, &styled) {
+                        (Some(ov), Some(base)) => {
+                            Some(ov.override_style(text, scope_name, base, &mut override_state))
+                        }
+                        (Some(ov), None) if !scope_name.is_empty() => {
+                            let base = Style::default();
+                            Some(ov.override_style(text, scope_name, &base, &mut override_state))
+                        }
+                        _ => styled,
+                    };
 
                     if fallback_bg.is_none() {
-                        write!(output, "{}", paint_with_background(text, styled, None))?;
+                        write!(
+                            output,
+                            "{}",
+                            paint_with_background(text, styled.as_ref(), None)
+                        )?;
                         continue;
                     }
 
@@ -140,7 +170,7 @@ impl Formatter for Terminal {
                             write!(
                                 output,
                                 "{}",
-                                paint_with_background(content, styled, fallback_bg)
+                                paint_with_background(content, styled.as_ref(), fallback_bg)
                             )?;
                             line_width += display_width(content);
                         }

--- a/crates/lumis-core/themes/astrodark.json
+++ b/crates/lumis-core/themes/astrodark.json
@@ -315,6 +315,27 @@
     "punctuation.special.rust": {
       "fg": "#dd97f1"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#5eb7ff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#4ac2b8"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#87c05f"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f5983a"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ff838b"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#dd97f1"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#dfab25"
+    },
     "string": {
       "fg": "#87c05f"
     },

--- a/crates/lumis-core/themes/astrojupiter.json
+++ b/crates/lumis-core/themes/astrojupiter.json
@@ -315,6 +315,27 @@
     "punctuation.special.rust": {
       "fg": "#90437a"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#006e89"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#007652"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#467118"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#954d00"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#a13f37"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#90437a"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#805c00"
+    },
     "string": {
       "fg": "#467118"
     },

--- a/crates/lumis-core/themes/astrolight.json
+++ b/crates/lumis-core/themes/astrolight.json
@@ -315,6 +315,27 @@
     "punctuation.special.rust": {
       "fg": "#9e007c"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#00508a"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#00615b"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#345e00"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#a34500"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#990000"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#9e007c"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#7300b8"
+    },
     "string": {
       "fg": "#345e00"
     },

--- a/crates/lumis-core/themes/astromars.json
+++ b/crates/lumis-core/themes/astromars.json
@@ -315,6 +315,27 @@
     "punctuation.special.rust": {
       "fg": "#cd87ba"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#4fa9c6"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#4fad97"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#84a860"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ef9474"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#df8489"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#cd87ba"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#c3963d"
+    },
     "string": {
       "fg": "#84a860"
     },

--- a/crates/lumis-core/themes/bamboo_light.json
+++ b/crates/lumis-core/themes/bamboo_light.json
@@ -290,6 +290,27 @@
     "punctuation.special.diff": {
       "fg": "#838781"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#1134a0"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#126877"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#1d6408"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#a7431d"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#95202d"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6838a7"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#7d5c00"
+    },
     "string": {
       "fg": "#27850b"
     },

--- a/crates/lumis-core/themes/bamboo_multiplex.json
+++ b/crates/lumis-core/themes/bamboo_multiplex.json
@@ -290,6 +290,27 @@
     "punctuation.special.diff": {
       "fg": "#818781"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#70b5e5"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#8ecbc2"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a1c382"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f3b374"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#e57b89"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#b8b3fa"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#dacb77"
+    },
     "string": {
       "fg": "#81af58"
     },

--- a/crates/lumis-core/themes/bamboo_vulgaris.json
+++ b/crates/lumis-core/themes/bamboo_vulgaris.json
@@ -290,6 +290,27 @@
     "punctuation.special.diff": {
       "fg": "#838781"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#81bcec"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#94d1ce"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#abc896"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ffb38c"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ed839d"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#bfbfff"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e4c87d"
+    },
     "string": {
       "fg": "#8fb573"
     },

--- a/crates/lumis-core/themes/bluloco_dark.json
+++ b/crates/lumis-core/themes/bluloco_dark.json
@@ -246,6 +246,27 @@
     "punctuation.special": {
       "fg": "#7c84da"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#42a4ff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#28e5eb"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#91f532"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ffa024"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ff6666"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#ff7aff"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f4ff7a"
+    },
     "string": {
       "fg": "#f9c958"
     },

--- a/crates/lumis-core/themes/bluloco_light.json
+++ b/crates/lumis-core/themes/bluloco_light.json
@@ -246,6 +246,27 @@
     "punctuation.special": {
       "fg": "#7c84da"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#0ab6ff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#0e92aa"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#1fc155"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ffa024"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f066f0"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#a557ff"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#b1b800"
+    },
     "string": {
       "fg": "#c4a231"
     },

--- a/crates/lumis-core/themes/carbonfox.json
+++ b/crates/lumis-core/themes/carbonfox.json
@@ -258,6 +258,24 @@
     "punctuation.special": {
       "fg": "#52bdff"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#78a9ff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#33b1ff"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#25be6a"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#3ddbd9"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ee5396"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#08bdba"
+    },
     "string": {
       "fg": "#25be6a"
     },

--- a/crates/lumis-core/themes/catppuccin_frappe.json
+++ b/crates/lumis-core/themes/catppuccin_frappe.json
@@ -344,6 +344,27 @@
     "punctuation.special": {
       "fg": "#f4b8e4"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#8caaee"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#81c8be"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a6d189"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ef9f76"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#e78284"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#ca9ee6"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e5c890"
+    },
     "string": {
       "fg": "#a6d189"
     },

--- a/crates/lumis-core/themes/catppuccin_latte.json
+++ b/crates/lumis-core/themes/catppuccin_latte.json
@@ -344,6 +344,27 @@
     "punctuation.special": {
       "fg": "#ea76cb"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#1e66f5"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#179299"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#40a02b"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#fe640b"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#d20f39"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#8839ef"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#df8e1d"
+    },
     "string": {
       "fg": "#40a02b"
     },

--- a/crates/lumis-core/themes/catppuccin_macchiato.json
+++ b/crates/lumis-core/themes/catppuccin_macchiato.json
@@ -344,6 +344,27 @@
     "punctuation.special": {
       "fg": "#f5bde6"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#8aadf4"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#8bd5ca"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a6da95"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f5a97f"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ed8796"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#c6a0f6"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#eed49f"
+    },
     "string": {
       "fg": "#a6da95"
     },

--- a/crates/lumis-core/themes/catppuccin_mocha.json
+++ b/crates/lumis-core/themes/catppuccin_mocha.json
@@ -344,6 +344,27 @@
     "punctuation.special": {
       "fg": "#f5c2e7"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#89b4fa"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#94e2d5"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a6e3a1"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#fab387"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f38ba8"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#cba6f7"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f9e2af"
+    },
     "string": {
       "fg": "#a6e3a1"
     },

--- a/crates/lumis-core/themes/citruszest.json
+++ b/crates/lumis-core/themes/citruszest.json
@@ -285,6 +285,27 @@
     "punctuation.special": {
       "fg": "#ffaa54"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#00bfff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#33ffff"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#1affa3"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ff7431"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ff1a75"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#af74ee"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ffff00"
+    },
     "string": {
       "fg": "#b2f3ac"
     },

--- a/crates/lumis-core/themes/cyberdream_dark.json
+++ b/crates/lumis-core/themes/cyberdream_dark.json
@@ -257,6 +257,27 @@
     "punctuation.special": {
       "fg": "#ffffff"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#5ea1ff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#5ef1ff"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#5eff6c"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ffbd5e"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ff6e5e"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#bd5eff"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f1ff5e"
+    },
     "string": {
       "fg": "#5eff6c"
     },

--- a/crates/lumis-core/themes/cyberdream_light.json
+++ b/crates/lumis-core/themes/cyberdream_light.json
@@ -257,6 +257,27 @@
     "punctuation.special": {
       "fg": "#16181a"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#0057d1"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#008c99"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#008b0c"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d17c00"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#d11500"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#a018ff"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#997b00"
+    },
     "string": {
       "fg": "#008b0c"
     },

--- a/crates/lumis-core/themes/dawnfox.json
+++ b/crates/lumis-core/themes/dawnfox.json
@@ -258,6 +258,24 @@
     "punctuation.special": {
       "fg": "#50848c"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#286983"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#56949f"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#618774"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d7827e"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#b4637a"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ea9d34"
+    },
     "string": {
       "fg": "#618774"
     },

--- a/crates/lumis-core/themes/dayfox.json
+++ b/crates/lumis-core/themes/dayfox.json
@@ -258,6 +258,24 @@
     "punctuation.special": {
       "fg": "#22676d"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#2848a9"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#287980"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#396847"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#955f61"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#a5222f"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ac5402"
+    },
     "string": {
       "fg": "#396847"
     },

--- a/crates/lumis-core/themes/deepwhite.json
+++ b/crates/lumis-core/themes/deepwhite.json
@@ -269,6 +269,27 @@
     "punctuation.special": {
       "fg": "#0000a6"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#0000a6"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#00a6a6"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#00a600"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f27900"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#a60000"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6f00a6"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f2f200"
+    },
     "string": {
       "fg": "#1a1918",
       "bg": "#d4fad4"

--- a/crates/lumis-core/themes/dracula.json
+++ b/crates/lumis-core/themes/dracula.json
@@ -276,6 +276,27 @@
       "fg": "#50fa7b",
       "italic": true
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#8be9fd"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#f8f8f2"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#bd93f9"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#50fa7b"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f8f8f2"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#ffb86c"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ff79c6"
+    },
     "string": {
       "fg": "#f1fa8c"
     },

--- a/crates/lumis-core/themes/dracula_soft.json
+++ b/crates/lumis-core/themes/dracula_soft.json
@@ -276,6 +276,27 @@
       "fg": "#87e58e",
       "italic": true
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#a7dfef"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#f6f6f5"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#baa0e8"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#87e58e"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f6f6f5"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#fdc38e"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e48cc1"
+    },
     "string": {
       "fg": "#e8eda2"
     },

--- a/crates/lumis-core/themes/duskfox.json
+++ b/crates/lumis-core/themes/duskfox.json
@@ -258,6 +258,24 @@
     "punctuation.special": {
       "fg": "#a6dae3"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#569fba"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#9ccfd8"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a3be8c"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ea9a97"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#eb6f92"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f6c177"
+    },
     "string": {
       "fg": "#a3be8c"
     },

--- a/crates/lumis-core/themes/edge_aura.json
+++ b/crates/lumis-core/themes/edge_aura.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#deb974"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#6cb6eb"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#5dbbc1"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a0c980"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d38aea"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ec7279"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#d38aea"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#deb974"
+    },
     "string": {
       "fg": "#a0c980"
     },

--- a/crates/lumis-core/themes/edge_dark.json
+++ b/crates/lumis-core/themes/edge_dark.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#deb974"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#6cb6eb"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#5dbbc1"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a0c980"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d38aea"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ec7279"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#d38aea"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#deb974"
+    },
     "string": {
       "fg": "#a0c980"
     },

--- a/crates/lumis-core/themes/edge_light.json
+++ b/crates/lumis-core/themes/edge_light.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#be7e05"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#5079be"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#3a8b84"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#608e32"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#b05ccc"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#d05858"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#b05ccc"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#be7e05"
+    },
     "string": {
       "fg": "#608e32"
     },

--- a/crates/lumis-core/themes/edge_neon.json
+++ b/crates/lumis-core/themes/edge_neon.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#deb974"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#6cb6eb"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#5dbbc1"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a0c980"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d38aea"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ec7279"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#d38aea"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#deb974"
+    },
     "string": {
       "fg": "#a0c980"
     },

--- a/crates/lumis-core/themes/eldritch.json
+++ b/crates/lumis-core/themes/eldritch.json
@@ -274,6 +274,27 @@
     "punctuation.special": {
       "fg": "#04d1f9"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#04d1f9"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#10a1bd"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a48cf2"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f7c67f"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f16c75"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#37f499"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f1fc79"
+    },
     "string": {
       "fg": "#f1fc79"
     },

--- a/crates/lumis-core/themes/everforest_dark.json
+++ b/crates/lumis-core/themes/everforest_dark.json
@@ -325,6 +325,27 @@
     "punctuation.special.typescript": {
       "fg": "#e69875"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#7fbbb3"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#83c092"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a7c080"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#e69875"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#e67e80"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#d699b6"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#dbbc7f"
+    },
     "string": {
       "fg": "#83c092"
     },

--- a/crates/lumis-core/themes/everforest_light.json
+++ b/crates/lumis-core/themes/everforest_light.json
@@ -325,6 +325,27 @@
     "punctuation.special.typescript": {
       "fg": "#f57d26"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#3a94c5"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#35a77c"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#8da101"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f57d26"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f85552"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#df69ba"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#dfa000"
+    },
     "string": {
       "fg": "#35a77c"
     },

--- a/crates/lumis-core/themes/gruber_darker.json
+++ b/crates/lumis-core/themes/gruber_darker.json
@@ -264,6 +264,27 @@
     "punctuation.special": {
       "fg": "#cc8c3c"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#96a6c8"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#95a99f"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#73d936"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cc8c3c"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ff4f58"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#9e95c7"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ffdd33"
+    },
     "string": {
       "fg": "#73d936",
       "italic": true

--- a/crates/lumis-core/themes/gruvbox_dark.json
+++ b/crates/lumis-core/themes/gruvbox_dark.json
@@ -262,6 +262,27 @@
     "punctuation.special": {
       "fg": "#fe8019"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#83a598"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#8ec07c"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#b8bb26"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#fe8019"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#fb4934"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#d3869b"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#fabd2f"
+    },
     "string": {
       "fg": "#b8bb26",
       "italic": true

--- a/crates/lumis-core/themes/gruvbox_dark_hard.json
+++ b/crates/lumis-core/themes/gruvbox_dark_hard.json
@@ -262,6 +262,27 @@
     "punctuation.special": {
       "fg": "#fe8019"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#83a598"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#8ec07c"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#b8bb26"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#fe8019"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#fb4934"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#d3869b"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#fabd2f"
+    },
     "string": {
       "fg": "#b8bb26",
       "italic": true

--- a/crates/lumis-core/themes/gruvbox_dark_soft.json
+++ b/crates/lumis-core/themes/gruvbox_dark_soft.json
@@ -262,6 +262,27 @@
     "punctuation.special": {
       "fg": "#fe8019"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#83a598"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#8ec07c"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#b8bb26"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#fe8019"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#fb4934"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#d3869b"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#fabd2f"
+    },
     "string": {
       "fg": "#b8bb26",
       "italic": true

--- a/crates/lumis-core/themes/gruvbox_light.json
+++ b/crates/lumis-core/themes/gruvbox_light.json
@@ -262,6 +262,27 @@
     "punctuation.special": {
       "fg": "#af3a03"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#076678"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#427b58"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#79740e"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#af3a03"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#9d0006"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#8f3f71"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#b57614"
+    },
     "string": {
       "fg": "#79740e",
       "italic": true

--- a/crates/lumis-core/themes/gruvbox_light_hard.json
+++ b/crates/lumis-core/themes/gruvbox_light_hard.json
@@ -262,6 +262,27 @@
     "punctuation.special": {
       "fg": "#af3a03"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#076678"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#427b58"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#79740e"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#af3a03"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#9d0006"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#8f3f71"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#b57614"
+    },
     "string": {
       "fg": "#79740e",
       "italic": true

--- a/crates/lumis-core/themes/gruvbox_light_soft.json
+++ b/crates/lumis-core/themes/gruvbox_light_soft.json
@@ -262,6 +262,27 @@
     "punctuation.special": {
       "fg": "#af3a03"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#076678"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#427b58"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#79740e"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#af3a03"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#9d0006"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#8f3f71"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#b57614"
+    },
     "string": {
       "fg": "#79740e",
       "italic": true

--- a/crates/lumis-core/themes/gruvbox_material_dark.json
+++ b/crates/lumis-core/themes/gruvbox_material_dark.json
@@ -301,6 +301,27 @@
     "punctuation.special.typescript": {
       "fg": "#e78a4e"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#7daea3"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#89b482"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a9b665"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#e78a4e"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ea6962"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#d3869b"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#d8a657"
+    },
     "string": {
       "fg": "#89b482"
     },

--- a/crates/lumis-core/themes/gruvbox_material_light.json
+++ b/crates/lumis-core/themes/gruvbox_material_light.json
@@ -301,6 +301,27 @@
     "punctuation.special.typescript": {
       "fg": "#c35e0a"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#45707a"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#4c7a5d"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#6c782e"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c35e0a"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#c14a4a"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#945e80"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#b47109"
+    },
     "string": {
       "fg": "#4c7a5d"
     },

--- a/crates/lumis-core/themes/horizon_dark.json
+++ b/crates/lumis-core/themes/horizon_dark.json
@@ -252,6 +252,27 @@
     "punctuation.special": {
       "fg": "#6c6d71"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#169fff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#25b0bc"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#29d398"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#db887a"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#d55070"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#a86ec9"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e4b28e"
+    },
     "string": {
       "fg": "#e4a88a"
     },

--- a/crates/lumis-core/themes/horizon_light.json
+++ b/crates/lumis-core/themes/horizon_light.json
@@ -227,6 +227,27 @@
     "punctuation.special": {
       "fg": "#333333"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#169fff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#1d8991"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#29d398"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#dc3318"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#da103f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#8a31b9"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f77d26"
+    },
     "string": {
       "fg": "#f6661e"
     },

--- a/crates/lumis-core/themes/kanagawa_paper_dark.json
+++ b/crates/lumis-core/themes/kanagawa_paper_dark.json
@@ -248,6 +248,27 @@
     "punctuation.special": {
       "fg": "#c4746e"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#658594"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#949fb5"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#699469"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#9d7665"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#c4746e"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#737c73"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#a292a3"
+    },
     "string": {
       "fg": "#8a9a7b"
     },

--- a/crates/lumis-core/themes/kanagawa_paper_light.json
+++ b/crates/lumis-core/themes/kanagawa_paper_light.json
@@ -248,6 +248,27 @@
     "punctuation.special": {
       "fg": "#c27672"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#809ba7"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#7e8faf"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#7e9579"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#a8826a"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#c27672"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#637263"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#9e7e98"
+    },
     "string": {
       "fg": "#7e9579"
     },

--- a/crates/lumis-core/themes/lackluster.json
+++ b/crates/lumis-core/themes/lackluster.json
@@ -247,6 +247,27 @@
     "punctuation.special": {
       "fg": "#7a7a7a"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#aaaaaa"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#dddddd"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#666666"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cccccc"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#555555"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#bbbbbb"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#999999"
+    },
     "string": {
       "fg": "#708090"
     },

--- a/crates/lumis-core/themes/lackluster_hack.json
+++ b/crates/lumis-core/themes/lackluster_hack.json
@@ -247,6 +247,27 @@
     "punctuation.special": {
       "fg": "#7a7a7a"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#aaaaaa"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#dddddd"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#666666"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cccccc"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#555555"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#bbbbbb"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#999999"
+    },
     "string": {
       "fg": "#708090"
     },

--- a/crates/lumis-core/themes/lackluster_mint.json
+++ b/crates/lumis-core/themes/lackluster_mint.json
@@ -247,6 +247,27 @@
     "punctuation.special": {
       "fg": "#7a7a7a"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#aaaaaa"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#dddddd"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#666666"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cccccc"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#555555"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#bbbbbb"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#999999"
+    },
     "string": {
       "fg": "#708090"
     },

--- a/crates/lumis-core/themes/melange_dark.json
+++ b/crates/lumis-core/themes/melange_dark.json
@@ -250,6 +250,27 @@
     "punctuation.special": {
       "fg": "#ebc06d"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#a3a9ce"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#89b3b6"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#85b695"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#e49b5d"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#d47766"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#b380b0"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ebc06d"
+    },
     "string": {
       "fg": "#a3a9ce",
       "italic": true

--- a/crates/lumis-core/themes/melange_light.json
+++ b/crates/lumis-core/themes/melange_light.json
@@ -250,6 +250,27 @@
     "punctuation.special": {
       "fg": "#a06d00"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#465aa4"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#3d6568"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#3a684a"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#bc5c00"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#bf0021"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#be79bb"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#a06d00"
+    },
     "string": {
       "fg": "#465aa4",
       "italic": true

--- a/crates/lumis-core/themes/modus_operandi.json
+++ b/crates/lumis-core/themes/modus_operandi.json
@@ -256,6 +256,27 @@
     "punctuation.special": {
       "fg": "#000000"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#0031a9"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#005e8b"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#006800"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#884900"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#a60000"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#531ab6"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#6f5500"
+    },
     "string": {
       "fg": "#3548cf"
     },

--- a/crates/lumis-core/themes/modus_vivendi.json
+++ b/crates/lumis-core/themes/modus_vivendi.json
@@ -256,6 +256,27 @@
     "punctuation.special": {
       "fg": "#ffffff"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#2fafff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#00d3d0"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#44bc44"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#fec43f"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ff5f59"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#b6a0ff"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#d0bc00"
+    },
     "string": {
       "fg": "#79a8ff"
     },

--- a/crates/lumis-core/themes/monokai_nightasty_dark.json
+++ b/crates/lumis-core/themes/monokai_nightasty_dark.json
@@ -257,6 +257,27 @@
     "punctuation.special": {
       "fg": "#fc1a70"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#0087ff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#62d8f1"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a4e400"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ff9700"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#fc1a70"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#af87ff"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ffff87"
+    },
     "string": {
       "fg": "#ffff87"
     },

--- a/crates/lumis-core/themes/monokai_nightasty_light.json
+++ b/crates/lumis-core/themes/monokai_nightasty_light.json
@@ -257,6 +257,27 @@
     "punctuation.special": {
       "fg": "#ff004b"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#0087ff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#00b3e3"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#4fb000"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ff4d00"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ff004b"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6054d0"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ff8f00"
+    },
     "string": {
       "fg": "#ff8f00"
     },

--- a/crates/lumis-core/themes/moonfly.json
+++ b/crates/lumis-core/themes/moonfly.json
@@ -320,6 +320,27 @@
     "punctuation.special": {
       "fg": "#e65e72"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#80a0ff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#79dac8"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#8cc85f"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#de935f"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ff5d5d"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#cf87e8"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e3c78a"
+    },
     "string": {
       "fg": "#c6c684"
     },

--- a/crates/lumis-core/themes/neofusion.json
+++ b/crates/lumis-core/themes/neofusion.json
@@ -262,6 +262,27 @@
     "punctuation.special": {
       "fg": "#fd5e3a"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#35b5ff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#66def9"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#008da3"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#fa7a61"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#fd5e3a"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#fd5e3a"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e2d9c5"
+    },
     "string": {
       "fg": "#35b5ff",
       "italic": true

--- a/crates/lumis-core/themes/night_owl.json
+++ b/crates/lumis-core/themes/night_owl.json
@@ -347,6 +347,15 @@
     "punctuation.special.bash": {
       "fg": "#c5e478"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#169fff"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#da70d6"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ffd602"
+    },
     "string": {
       "fg": "#ecc48d"
     },

--- a/crates/lumis-core/themes/nightfly.json
+++ b/crates/lumis-core/themes/nightfly.json
@@ -320,6 +320,27 @@
     "punctuation.special": {
       "fg": "#ff5874"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#82aaff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#7fdbca"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a1cd5e"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f78c6c"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#fc514e"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#c792ea"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e3d18a"
+    },
     "string": {
       "fg": "#ecc48d"
     },

--- a/crates/lumis-core/themes/nightfox.json
+++ b/crates/lumis-core/themes/nightfox.json
@@ -258,6 +258,24 @@
     "punctuation.special": {
       "fg": "#7ad5d6"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#719cd6"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#63cdcf"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#81b29a"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f4a261"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#c94f6d"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#dbc074"
+    },
     "string": {
       "fg": "#81b29a"
     },

--- a/crates/lumis-core/themes/nord.json
+++ b/crates/lumis-core/themes/nord.json
@@ -284,6 +284,27 @@
     "punctuation.special": {
       "fg": "#88c0d0"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#81a1c1"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#88c0d0"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a3be8c"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d08770"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#bf616a"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#b48ead"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ebcb8b"
+    },
     "string": {
       "fg": "#a3be8c",
       "italic": true

--- a/crates/lumis-core/themes/nordfox.json
+++ b/crates/lumis-core/themes/nordfox.json
@@ -258,6 +258,24 @@
     "punctuation.special": {
       "fg": "#93ccdc"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#81a1c1"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#88c0d0"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a3be8c"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c9826b"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#bf616a"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ebcb8b"
+    },
     "string": {
       "fg": "#a3be8c"
     },

--- a/crates/lumis-core/themes/nordic.json
+++ b/crates/lumis-core/themes/nordic.json
@@ -255,6 +255,21 @@
       "fg": "#d08770",
       "bold": true
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#88c0d0"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#b1c89d"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d08770"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#c5727a"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#efd49f"
+    },
     "string": {
       "fg": "#a3be8c"
     },

--- a/crates/lumis-core/themes/obscure.json
+++ b/crates/lumis-core/themes/obscure.json
@@ -272,6 +272,34 @@
     "punctuation.special": {
       "fg": "#b4b1ba"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#6a8cbc",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#85b5ba",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#90b99f",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c88477",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#c45570",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#8787bf",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#bc9781",
+      "bg": "#161617"
+    },
     "string": {
       "fg": "#90b99f"
     },

--- a/crates/lumis-core/themes/oldworld.json
+++ b/crates/lumis-core/themes/oldworld.json
@@ -256,6 +256,34 @@
     "punctuation.special": {
       "fg": "#b4b1ba"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#92a2d5",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#85b5ba",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#90b99f",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f5a191",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ea83a5",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#aca1cf",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e6b99d",
+      "bg": "#161617"
+    },
     "string": {
       "fg": "#90b99f"
     },

--- a/crates/lumis-core/themes/oldworld_cooler.json
+++ b/crates/lumis-core/themes/oldworld_cooler.json
@@ -256,6 +256,34 @@
     "punctuation.special": {
       "fg": "#b2b1ba"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#92b3d5",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#85bab2",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#90b995",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f5919a",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ea83bf",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#a1a1cf",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e6a79d",
+      "bg": "#161617"
+    },
     "string": {
       "fg": "#90b995"
     },

--- a/crates/lumis-core/themes/oldworld_oled.json
+++ b/crates/lumis-core/themes/oldworld_oled.json
@@ -256,6 +256,34 @@
     "punctuation.special": {
       "fg": "#b4b1ba"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#92a2d5",
+      "bg": "#000000"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#85b5ba",
+      "bg": "#000000"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#90b99f",
+      "bg": "#000000"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f5a191",
+      "bg": "#000000"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ea83a5",
+      "bg": "#000000"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#aca1cf",
+      "bg": "#000000"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e6b99d",
+      "bg": "#000000"
+    },
     "string": {
       "fg": "#90b99f"
     },

--- a/crates/lumis-core/themes/one_monokai.json
+++ b/crates/lumis-core/themes/one_monokai.json
@@ -243,6 +243,27 @@
     "punctuation.special": {
       "fg": "#c678dd"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#61afef"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#56b6c2"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#98c379"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d19a66"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#d03770"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#c678dd"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e5c07b"
+    },
     "string": {
       "fg": "#e5c07b"
     },

--- a/crates/lumis-core/themes/onedark.json
+++ b/crates/lumis-core/themes/onedark.json
@@ -392,6 +392,27 @@
     "punctuation.special.markdown": {
       "fg": "#7f848e"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#61afef"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#56b6c2"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#98c379"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d19a66"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#e06c75"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#c678dd"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e5c07b"
+    },
     "string": {
       "fg": "#98c379"
     },

--- a/crates/lumis-core/themes/onedark_cool.json
+++ b/crates/lumis-core/themes/onedark_cool.json
@@ -258,6 +258,27 @@
     "punctuation.special": {
       "fg": "#ef5f6b"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#5ab0f6"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#4dbdcb"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#97ca72"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d99a5e"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ef5f6b"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#ca72e4"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ebc275"
+    },
     "string": {
       "fg": "#97ca72"
     },

--- a/crates/lumis-core/themes/onedark_darker.json
+++ b/crates/lumis-core/themes/onedark_darker.json
@@ -258,6 +258,27 @@
     "punctuation.special": {
       "fg": "#e55561"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#4fa6ed"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#48b0bd"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#8ebd6b"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cc9057"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#e55561"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#bf68d9"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e2b86b"
+    },
     "string": {
       "fg": "#8ebd6b"
     },

--- a/crates/lumis-core/themes/onedark_deep.json
+++ b/crates/lumis-core/themes/onedark_deep.json
@@ -258,6 +258,27 @@
     "punctuation.special": {
       "fg": "#f65866"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#41a7fc"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#34bfd0"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#8bcd5b"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#dd9046"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f65866"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#c75ae8"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#efbd5d"
+    },
     "string": {
       "fg": "#8bcd5b"
     },

--- a/crates/lumis-core/themes/onedark_light.json
+++ b/crates/lumis-core/themes/onedark_light.json
@@ -258,6 +258,27 @@
     "punctuation.special": {
       "fg": "#e45649"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#4078f2"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#0184bc"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#50a14f"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c18401"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#e45649"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#a626a4"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#986801"
+    },
     "string": {
       "fg": "#50a14f"
     },

--- a/crates/lumis-core/themes/onedark_warm.json
+++ b/crates/lumis-core/themes/onedark_warm.json
@@ -258,6 +258,27 @@
     "punctuation.special": {
       "fg": "#e16d77"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#68aee8"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#5fafb9"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#99bc80"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c99a6e"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#e16d77"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#c27fd7"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#dfbe81"
+    },
     "string": {
       "fg": "#99bc80"
     },

--- a/crates/lumis-core/themes/onedark_warmer.json
+++ b/crates/lumis-core/themes/onedark_warmer.json
@@ -258,6 +258,27 @@
     "punctuation.special": {
       "fg": "#de5d68"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#57a5e5"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#51a8b3"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#8fb573"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c49060"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#de5d68"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#bb70d2"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#dbb671"
+    },
     "string": {
       "fg": "#8fb573"
     },

--- a/crates/lumis-core/themes/onedarkpro_dark.json
+++ b/crates/lumis-core/themes/onedarkpro_dark.json
@@ -392,6 +392,27 @@
     "punctuation.special.markdown": {
       "fg": "#7f848e"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#61afef"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#2bbac5"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#89ca78"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d19a66"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ef596f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#d55fde"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e5c07b"
+    },
     "string": {
       "fg": "#89ca78"
     },

--- a/crates/lumis-core/themes/onedarkpro_vivid.json
+++ b/crates/lumis-core/themes/onedarkpro_vivid.json
@@ -392,6 +392,27 @@
     "punctuation.special.markdown": {
       "fg": "#7f848e"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#61afef"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#2bbac5"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#89ca78"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d19a66"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ef596f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#d55fde"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e5c07b"
+    },
     "string": {
       "fg": "#89ca78"
     },

--- a/crates/lumis-core/themes/onelight.json
+++ b/crates/lumis-core/themes/onelight.json
@@ -392,6 +392,27 @@
     "punctuation.special.markdown": {
       "fg": "#9b9fa6"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#118dc3"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#56b6c2"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#1da912"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ee9025"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#e05661"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#9a77cf"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#eea825"
+    },
     "string": {
       "fg": "#1da912"
     },

--- a/crates/lumis-core/themes/rosepine_dark.json
+++ b/crates/lumis-core/themes/rosepine_dark.json
@@ -289,6 +289,27 @@
     "punctuation.special": {
       "fg": "#908caa"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#31748f"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#9ccfd8"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#95b1ac"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ebbcba"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#eb6f92"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#c4a7e7"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f6c177"
+    },
     "string": {
       "fg": "#f6c177"
     },

--- a/crates/lumis-core/themes/rosepine_dawn.json
+++ b/crates/lumis-core/themes/rosepine_dawn.json
@@ -289,6 +289,27 @@
     "punctuation.special": {
       "fg": "#797593"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#286983"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#56949f"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#6d8f89"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d7827e"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#b4637a"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#907aa9"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ea9d34"
+    },
     "string": {
       "fg": "#ea9d34"
     },

--- a/crates/lumis-core/themes/rosepine_moon.json
+++ b/crates/lumis-core/themes/rosepine_moon.json
@@ -289,6 +289,27 @@
     "punctuation.special": {
       "fg": "#908caa"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#3e8fb0"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#9ccfd8"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#95b1ac"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ea9a97"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#eb6f92"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#c4a7e7"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f6c177"
+    },
     "string": {
       "fg": "#f6c177"
     },

--- a/crates/lumis-core/themes/solarized_autumn_dark.json
+++ b/crates/lumis-core/themes/solarized_autumn_dark.json
@@ -254,6 +254,24 @@
     "punctuation.special": {
       "fg": "#859900"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd2"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#2aa198"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#859900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cb4b16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#dc322f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6c71c4"
+    },
     "string": {
       "fg": "#2aa198"
     },

--- a/crates/lumis-core/themes/solarized_autumn_light.json
+++ b/crates/lumis-core/themes/solarized_autumn_light.json
@@ -255,6 +255,24 @@
     "punctuation.special": {
       "fg": "#859900"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd2"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#2aa198"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#859900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cb4b16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#dc322f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6c71c4"
+    },
     "string": {
       "fg": "#2aa198"
     },

--- a/crates/lumis-core/themes/solarized_osaka_dark.json
+++ b/crates/lumis-core/themes/solarized_osaka_dark.json
@@ -268,6 +268,27 @@
       "fg": "#c94c16",
       "bold": true
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd3"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#29a298"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#849900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c94c16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#db302d"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6d71c4"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#b28500"
+    },
     "string": {
       "fg": "#29a298"
     },

--- a/crates/lumis-core/themes/solarized_osaka_light.json
+++ b/crates/lumis-core/themes/solarized_osaka_light.json
@@ -268,6 +268,27 @@
       "fg": "#c94c16",
       "bold": true
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd3"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#29a298"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#849900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c94c16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#db302d"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6d71c4"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#b28500"
+    },
     "string": {
       "fg": "#29a298"
     },

--- a/crates/lumis-core/themes/solarized_osaka_storm.json
+++ b/crates/lumis-core/themes/solarized_osaka_storm.json
@@ -268,6 +268,27 @@
       "fg": "#c94c16",
       "bold": true
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd3"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#29a298"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#849900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c94c16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#db302d"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6d71c4"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#b28500"
+    },
     "string": {
       "fg": "#29a298"
     },

--- a/crates/lumis-core/themes/solarized_spring_dark.json
+++ b/crates/lumis-core/themes/solarized_spring_dark.json
@@ -254,6 +254,24 @@
     "punctuation.special": {
       "fg": "#859900"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd2"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#2aa198"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#859900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cb4b16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#dc322f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6c71c4"
+    },
     "string": {
       "fg": "#2aa198"
     },

--- a/crates/lumis-core/themes/solarized_spring_light.json
+++ b/crates/lumis-core/themes/solarized_spring_light.json
@@ -255,6 +255,24 @@
     "punctuation.special": {
       "fg": "#859900"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd2"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#2aa198"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#859900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cb4b16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#dc322f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6c71c4"
+    },
     "string": {
       "fg": "#2aa198"
     },

--- a/crates/lumis-core/themes/solarized_summer_dark.json
+++ b/crates/lumis-core/themes/solarized_summer_dark.json
@@ -251,6 +251,24 @@
     "punctuation.special": {
       "fg": "#859900"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd2"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#2aa198"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#859900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cb4b16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#dc322f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6c71c4"
+    },
     "string": {
       "fg": "#2aa198"
     },

--- a/crates/lumis-core/themes/solarized_summer_light.json
+++ b/crates/lumis-core/themes/solarized_summer_light.json
@@ -252,6 +252,24 @@
     "punctuation.special": {
       "fg": "#859900"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd2"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#2aa198"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#859900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cb4b16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#dc322f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6c71c4"
+    },
     "string": {
       "fg": "#2aa198"
     },

--- a/crates/lumis-core/themes/solarized_winter_dark.json
+++ b/crates/lumis-core/themes/solarized_winter_dark.json
@@ -265,6 +265,24 @@
       "fg": "#93a1a1",
       "bold": true
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd2"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#2aa198"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#859900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cb4b16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#dc322f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6c71c4"
+    },
     "string": {
       "fg": "#2aa198"
     },

--- a/crates/lumis-core/themes/solarized_winter_light.json
+++ b/crates/lumis-core/themes/solarized_winter_light.json
@@ -264,6 +264,24 @@
       "fg": "#586e75",
       "bold": true
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd2"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#2aa198"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#859900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cb4b16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#dc322f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6c71c4"
+    },
     "string": {
       "fg": "#2aa198"
     },

--- a/crates/lumis-core/themes/sonokai_andromeda.json
+++ b/crates/lumis-core/themes/sonokai_andromeda.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#edc763"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#6dcae8"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#6dcae8"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#9ed06c"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f89860"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#fb617e"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#bb97ee"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#edc763"
+    },
     "string": {
       "fg": "#edc763"
     },

--- a/crates/lumis-core/themes/sonokai_atlantis.json
+++ b/crates/lumis-core/themes/sonokai_atlantis.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#eacb64"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#72cce8"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#72cce8"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#9dd274"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f69c5e"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ff6578"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#ba9cf3"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#eacb64"
+    },
     "string": {
       "fg": "#eacb64"
     },

--- a/crates/lumis-core/themes/sonokai_default.json
+++ b/crates/lumis-core/themes/sonokai_default.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#e7c664"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#76cce0"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#76cce0"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#9ed072"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f39660"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#fc5d7c"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#b39df3"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e7c664"
+    },
     "string": {
       "fg": "#e7c664"
     },

--- a/crates/lumis-core/themes/sonokai_espresso.json
+++ b/crates/lumis-core/themes/sonokai_espresso.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#f0c66f"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#81d0c9"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#81d0c9"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a6cd77"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f08d71"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f86882"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#9fa0e1"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f0c66f"
+    },
     "string": {
       "fg": "#f0c66f"
     },

--- a/crates/lumis-core/themes/sonokai_maia.json
+++ b/crates/lumis-core/themes/sonokai_maia.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#e3d367"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#78cee9"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#78cee9"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#9cd57b"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f3a96a"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f76c7c"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#baa0f8"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e3d367"
+    },
     "string": {
       "fg": "#e3d367"
     },

--- a/crates/lumis-core/themes/sonokai_shusia.json
+++ b/crates/lumis-core/themes/sonokai_shusia.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#e5c463"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#7accd7"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#7accd7"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#9ecd6f"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ef9062"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f85e84"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#ab9df2"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e5c463"
+    },
     "string": {
       "fg": "#e5c463"
     },

--- a/crates/lumis-core/themes/terafox.json
+++ b/crates/lumis-core/themes/terafox.json
@@ -258,6 +258,24 @@
     "punctuation.special": {
       "fg": "#afd4de"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#5a93aa"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#a1cdd8"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#7aa4a1"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ff8349"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#e85c51"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#fda47f"
+    },
     "string": {
       "fg": "#7aa4a1"
     },

--- a/crates/lumis-core/themes/tokyonight_day.json
+++ b/crates/lumis-core/themes/tokyonight_day.json
@@ -288,6 +288,27 @@
     "punctuation.special.markdown": {
       "fg": "#b15c00"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#2e7de9"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#007197"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#587539"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#b15c00"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f52a65"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#7847bd"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#8c6c3e"
+    },
     "string": {
       "fg": "#587539"
     },

--- a/crates/lumis-core/themes/tokyonight_moon.json
+++ b/crates/lumis-core/themes/tokyonight_moon.json
@@ -278,6 +278,27 @@
     "punctuation.special.markdown": {
       "fg": "#ff966c"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#82aaff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#86e1fc"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#c3e88d"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ff966c"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ff757f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#fca7ea"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ffc777"
+    },
     "string": {
       "fg": "#c3e88d"
     },

--- a/crates/lumis-core/themes/tokyonight_night.json
+++ b/crates/lumis-core/themes/tokyonight_night.json
@@ -288,6 +288,27 @@
     "punctuation.special.markdown": {
       "fg": "#ff9e64"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#7aa2f7"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#7dcfff"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#9ece6a"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ff9e64"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f7768e"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#9d7cd8"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e0af68"
+    },
     "string": {
       "fg": "#9ece6a"
     },

--- a/crates/lumis-core/themes/tokyonight_storm.json
+++ b/crates/lumis-core/themes/tokyonight_storm.json
@@ -288,6 +288,27 @@
     "punctuation.special.markdown": {
       "fg": "#ff9e64"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#7aa2f7"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#7dcfff"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#9ece6a"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ff9e64"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f7768e"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#9d7cd8"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e0af68"
+    },
     "string": {
       "fg": "#9ece6a"
     },

--- a/crates/lumis-core/themes/vague.json
+++ b/crates/lumis-core/themes/vague.json
@@ -261,6 +261,27 @@
     "punctuation.special": {
       "fg": "#6e94b2"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#7e98e8"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#6e94b2"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#7fa563"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c48282"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#d8647e"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#bb9dbd"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f3be7c"
+    },
     "string": {
       "fg": "#e8b589",
       "italic": true

--- a/crates/lumis-core/themes/vscode_dark.json
+++ b/crates/lumis-core/themes/vscode_dark.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#d4d4d4"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#18a2fe"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#4ec9b0"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#6a9955"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ce9178"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#c586c0"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#646695"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#d7ba7d"
+    },
     "string": {
       "fg": "#ce9178"
     },

--- a/crates/lumis-core/themes/vscode_light.json
+++ b/crates/lumis-core/themes/vscode_light.json
@@ -294,6 +294,27 @@
     "punctuation.special": {
       "fg": "#343434"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#18a2fe"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#16825d"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#008000"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c72e0f"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#af00db"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#000080"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#800000"
+    },
     "string": {
       "fg": "#c72e0f"
     },

--- a/crates/lumis/src/formatter/mod.rs
+++ b/crates/lumis/src/formatter/mod.rs
@@ -166,6 +166,8 @@ pub mod terminal;
 pub use terminal::Background as TerminalBackground;
 pub use terminal::{Terminal, TerminalBuilder};
 
+pub use lumis_core::formatter::RainbowBrackets;
+
 pub mod bbcode;
 pub use bbcode::{BBCodeScoped, BBCodeScopedBuilder};
 

--- a/crates/lumis/src/formatter/terminal.rs
+++ b/crates/lumis/src/formatter/terminal.rs
@@ -22,7 +22,9 @@ use crate::themes::Theme;
 use derive_builder::Builder;
 pub use lumis_core::formatter::terminal::Background;
 use lumis_core::formatter::Formatter as _;
+pub use lumis_core::formatter::StyleOverride;
 use std::io::{self, Write};
+use std::sync::Arc;
 
 /// Terminal formatter for syntax highlighting with ANSI color codes.
 ///
@@ -55,6 +57,7 @@ pub struct Terminal {
     theme: Option<Theme>,
     background: Background,
     width: Option<usize>,
+    style_override: Option<Arc<dyn StyleOverride>>,
 }
 
 impl TerminalBuilder {
@@ -85,7 +88,16 @@ impl Terminal {
             theme,
             background,
             width,
+            style_override: None,
         }
+    }
+
+    pub fn with_style_override(
+        mut self,
+        style_override: Arc<dyn lumis_core::formatter::StyleOverride>,
+    ) -> Self {
+        self.style_override = Some(style_override);
+        self
     }
 }
 
@@ -96,6 +108,7 @@ impl Default for Terminal {
             theme: None,
             background: Background::Inherit,
             width: None,
+            style_override: None,
         }
     }
 }
@@ -105,19 +118,26 @@ impl Formatter for Terminal {
         let events =
             highlight::highlight_events(source, self.language).map_err(io::Error::other)?;
 
-        let core_formatter = lumis_core::formatter::terminal::Terminal::new(
+        let mut core_formatter = lumis_core::formatter::terminal::Terminal::new(
             self.language,
             self.theme.clone(),
             self.background.clone(),
             self.width,
         );
+
+        if let Some(style_override) = &self.style_override {
+            core_formatter = core_formatter.with_style_override(Arc::clone(style_override));
+        }
+
         core_formatter.render(source, &events, output)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::super::RainbowBrackets;
     use super::*;
+    use crate::themes;
 
     #[test]
     fn test_no_attrs() {
@@ -130,6 +150,91 @@ mod tests {
         assert!(result.contains("@"));
         assert!(result.contains("lang"));
         assert!(result.contains(":rust"));
-        // Without a theme, some tokens may not have styling, so just check the text is there
+    }
+
+    #[test]
+    fn test_rainbow_brackets() {
+        let code = "{:ok, [1, 2]}";
+        let formatter = TerminalBuilder::new()
+            .language(Language::Elixir)
+            .theme(themes::get("onedark").ok())
+            .style_override(Some(Arc::new(RainbowBrackets::new(vec![
+                "#e06c75".to_string(),
+                "#61afef".to_string(),
+                "#98c379".to_string(),
+                "#e5c07b".to_string(),
+                "#c678dd".to_string(),
+                "#56b6c2".to_string(),
+            ]))))
+            .build()
+            .unwrap();
+
+        let mut buffer = Vec::new();
+        formatter.format(code, &mut buffer).unwrap();
+        let result = String::from_utf8_lossy(&buffer);
+
+        // { at depth 0 -> red
+        assert!(result.contains("\u{1b}[38;2;224;108;117m{"));
+        // [ at depth 1 -> blue
+        assert!(result.contains("\u{1b}[38;2;97;175;239m["));
+        // ] at depth 1 -> blue (closing)
+        assert!(result.contains("\u{1b}[38;2;97;175;239m]"));
+        // } at depth 0 -> red (closing)
+        assert!(result.contains("\u{1b}[38;2;224;108;117m}"));
+    }
+
+    #[test]
+    fn test_rainbow_brackets_custom_colors() {
+        let code = "(a)";
+        let formatter = TerminalBuilder::new()
+            .language(Language::Rust)
+            .theme(themes::get("onedark").ok())
+            .style_override(Some(Arc::new(RainbowBrackets::new(vec![
+                "#ff0000".to_string()
+            ]))))
+            .build()
+            .unwrap();
+
+        let mut buffer = Vec::new();
+        formatter.format(code, &mut buffer).unwrap();
+        let result = String::from_utf8_lossy(&buffer);
+
+        assert!(result.contains("\u{1b}[38;2;255;0;0m("));
+        assert!(result.contains("\u{1b}[38;2;255;0;0m)"));
+    }
+
+    #[test]
+    fn test_no_override_by_default() {
+        let code = "{:ok}";
+        let formatter = TerminalBuilder::new()
+            .language(Language::Elixir)
+            .build()
+            .unwrap();
+
+        let mut buffer = Vec::new();
+        formatter.format(code, &mut buffer).unwrap();
+        let result = String::from_utf8_lossy(&buffer);
+
+        // No rainbow colors without style_override set
+        assert!(!result.contains("\u{1b}[38;2;224;108;117m{"));
+    }
+
+    #[test]
+    fn test_rainbow_brackets_without_theme() {
+        let code = "{:ok}";
+        let formatter = TerminalBuilder::new()
+            .language(Language::Elixir)
+            .style_override(Some(Arc::new(RainbowBrackets::new(vec![
+                "#ff0000".to_string()
+            ]))))
+            .build()
+            .unwrap();
+
+        let mut buffer = Vec::new();
+        formatter.format(code, &mut buffer).unwrap();
+        let result = String::from_utf8_lossy(&buffer);
+
+        // Rainbow colors apply even without a theme
+        assert!(result.contains("\u{1b}[38;2;255;0;0m{"));
     }
 }

--- a/docs/content/cli/commands.mdx
+++ b/docs/content/cli/commands.mdx
@@ -55,6 +55,7 @@ echo 'const x = 1' | lumis highlight -l javascript --formatter html-inline --the
 | `--default-theme <id>` | | Which `--themes` entry gets inline styles |
 | `--css-variable-prefix <prefix>` | | Prefix for CSS custom properties (default: `--lumis`) |
 | `--highlight-lines <lines>` | `-h` | Lines to highlight (e.g., `1,3-5,10`) |
+| `--rainbow-brackets` | | Color nested brackets by depth (terminal formatter). See [Rainbow brackets](/formatters/terminal#rainbow-brackets). |
 
 ### Examples
 
@@ -76,6 +77,10 @@ lumis highlight main.rs \
 
 ```bash title="BBCode Scoped"
 lumis highlight main.rs -f bbcode-scoped
+```
+
+```bash title="Rainbow brackets"
+lumis highlight main.rs --theme dracula --rainbow-brackets
 ```
 
 ```bash title="Verbose mode — see cache hits and parser paths"

--- a/docs/content/usage/formatters/terminal.mdx
+++ b/docs/content/usage/formatters/terminal.mdx
@@ -20,11 +20,11 @@ ANSI escape codes for shell output.
 
 | Runtime | Options |
 | --- | --- |
-| Rust | `language`, `theme`, `background`, `width` |
-| Elixir | `language`, `theme`, `background`, `width` |
+| Rust | `language`, `theme`, `background`, `width`, `style_override` |
+| Elixir | `language`, `theme`, `background`, `width`, `rainbow_brackets` |
 | JavaScript | `language`, `theme` |
 | Java | `withLang()`, `withTheme()`, `withFormatter(Formatter.TERMINAL)` |
-| CLI | default formatter, `--theme`, `--background`, `--width` |
+| CLI | default formatter, `--theme`, `--background`, `--width`, `--rainbow-brackets` |
 
 ## Example
 
@@ -126,3 +126,61 @@ Terminal output is plain text wrapped in ANSI escape sequences:
 - CLI tools
 - logs and local scripts
 - previewing highlighted code in a terminal
+
+## Rainbow brackets
+
+Color nested bracket pairs with a cycling palette so matching delimiters are visually distinct.
+
+<Tabs groupId="runtime" queryString="lang" defaultValue="elixir">
+  <TabItem value="elixir" label="Elixir">
+
+```elixir
+# Use default palette
+Lumis.highlight!(
+  "{:ok, [1, 2]}",
+  formatter: {:terminal, language: "elixir", theme: "dracula", rainbow_brackets: true}
+)
+
+# Custom palette
+Lumis.highlight!(
+  "{:ok, [1, 2]}",
+  formatter:
+    {:terminal,
+     language: "elixir",
+     theme: "dracula",
+     rainbow_brackets: %Lumis.RainbowBrackets{colors: ["#ff0000", "#00ff00", "#0000ff"]}}
+)
+```
+
+  </TabItem>
+  <TabItem value="rust" label="Rust">
+
+```rust
+use lumis::{TerminalBuilder, formatters::RainbowBrackets, languages::Language, themes, formatters::Formatter};
+use std::sync::Arc;
+
+let colors = vec!["#e06c75".into(), "#61afef".into(), "#98c379".into()];
+let formatter = TerminalBuilder::new()
+    .language(Language::Elixir)
+    .theme(Some(themes::get("dracula").unwrap()))
+    .style_override(Some(Arc::new(RainbowBrackets::new(colors))))
+    .build()
+    .unwrap();
+
+let ansi = lumis::highlight("{:ok, [1, 2]}", formatter);
+println!("{}", ansi);
+```
+
+  </TabItem>
+  <TabItem value="cli" label="CLI">
+
+```bash
+lumis highlight code.ex --theme dracula --rainbow-brackets
+```
+
+  </TabItem>
+</Tabs>
+
+Default palette: `#e06c75`, `#61afef`, `#98c379`, `#e5c07b`, `#c678dd`, `#56b6c2` (6 colors cycling by nesting depth).
+
+This feature is currently available in Rust, Elixir, and CLI. JavaScript and Java support may be added in a future release.

--- a/docs/content/usage/formatters/terminal.mdx
+++ b/docs/content/usage/formatters/terminal.mdx
@@ -157,13 +157,12 @@ Lumis.highlight!(
 
 ```rust
 use lumis::{TerminalBuilder, formatters::RainbowBrackets, languages::Language, themes, formatters::Formatter};
-use std::sync::Arc;
 
-let colors = vec!["#e06c75".into(), "#61afef".into(), "#98c379".into()];
+let theme = themes::get("dracula").unwrap();
 let formatter = TerminalBuilder::new()
     .language(Language::Elixir)
-    .theme(Some(themes::get("dracula").unwrap()))
-    .style_override(Some(Arc::new(RainbowBrackets::new(colors))))
+    .theme(Some(theme.clone()))
+    .style_override(Some(RainbowBrackets::from_theme(Some(&theme)).into_override()))
     .build()
     .unwrap();
 
@@ -181,6 +180,6 @@ lumis highlight code.ex --theme dracula --rainbow-brackets
   </TabItem>
 </Tabs>
 
-Default palette: `#e06c75`, `#61afef`, `#98c379`, `#e5c07b`, `#c678dd`, `#56b6c2` (6 colors cycling by nesting depth).
+Default palette comes from the selected theme's standard `RainbowDelimiterRed`, `RainbowDelimiterYellow`, `RainbowDelimiterBlue`, `RainbowDelimiterOrange`, `RainbowDelimiterGreen`, `RainbowDelimiterViolet`, and `RainbowDelimiterCyan` highlight groups when available. Missing colors fall back to `#e06c75`, `#e5c07b`, `#61afef`, `#d19a66`, `#98c379`, `#c678dd`, `#56b6c2`.
 
 This feature is currently available in Rust, Elixir, and CLI. JavaScript and Java support may be added in a future release.

--- a/packages/elixir/lumis/lib/lumis.ex
+++ b/packages/elixir/lumis/lib/lumis.ex
@@ -140,6 +140,7 @@ defmodule Lumis do
       - `:theme` (`t:theme/0` - default: `nil`) - the theme to apply styles on the highlighted source code.
       - `:background` (`:theme | t:String.t/0 | nil` - default: `nil`) - fallback background behavior: `nil` inherits the output background, `:theme` uses the theme's normal background color, and a string uses that color.
       - `:width` (`pos_integer() | nil` - default: `nil`) - pad each rendered terminal line to the given width. This is most useful with `:background`.
+      - `:rainbow_brackets` (`t:boolean/0` | `%Lumis.RainbowBrackets{}` - default: `false`) - when `true`, color nested brackets with a default palette. Pass a `%Lumis.RainbowBrackets{}` struct to customize colors.
 
   * `bbcode_scoped`:
 
@@ -223,6 +224,10 @@ defmodule Lumis do
 
       {:terminal, theme: "dracula", background: "#282a36", width: 120}
 
+      {:terminal, theme: "dracula", rainbow_brackets: true}
+
+      {:terminal, theme: "dracula", rainbow_brackets: %Lumis.RainbowBrackets{colors: ["#ff0000", "#00ff00", "#0000ff"]}}
+
   ### BBCode Scoped formatter
 
       :bbcode_scoped
@@ -270,7 +275,8 @@ defmodule Lumis do
                language: language(),
                theme: theme(),
                background: :theme | String.t() | nil,
-               width: pos_integer() | nil
+               width: pos_integer() | nil,
+               rainbow_brackets: boolean() | Lumis.RainbowBrackets.t() | nil
              ]}
           | :bbcode_scoped
           | {:bbcode_scoped, [language: language()]}
@@ -488,12 +494,22 @@ defmodule Lumis do
       language: [type: {:or, [:string, nil]}, default: nil],
       theme: [type: {:or, [{:struct, Lumis.Theme}, :string, nil]}, default: @default_theme],
       background: [type: {:or, [:string, {:in, [:theme]}, nil]}, default: nil],
-      width: [type: {:or, [:pos_integer, nil]}, default: nil]
+      width: [type: {:or, [:pos_integer, nil]}, default: nil],
+      rainbow_brackets: [
+        type: {:or, [{:in, [true, false]}, {:struct, Lumis.RainbowBrackets}, nil]},
+        default: nil
+      ]
     ]
 
     case NimbleOptions.validate(options, schema) do
       {:ok, validated_opts} ->
-        {:ok, {:terminal, validated_opts}}
+        case validated_opts[:rainbow_brackets] do
+          %Lumis.RainbowBrackets{colors: []} ->
+            {:error, "rainbow_brackets colors must not be empty"}
+
+          _ ->
+            {:ok, {:terminal, validated_opts}}
+        end
 
       {:error, error} ->
         {:error, "invalid options given to terminal: #{inspect(error)}"}
@@ -994,7 +1010,17 @@ defmodule Lumis do
         nil -> Map.put(opts, :background, nil)
       end
 
-    {:terminal, Map.take(opts, [:theme, :background, :width])}
+    rainbow_brackets =
+      case opts[:rainbow_brackets] do
+        true -> Lumis.RainbowBrackets.new()
+        %Lumis.RainbowBrackets{} = rb -> rb
+        false -> nil
+        nil -> nil
+      end
+
+    opts = Map.put(opts, :rainbow_brackets, rainbow_brackets)
+
+    {:terminal, Map.take(opts, [:theme, :background, :width, :rainbow_brackets])}
   end
 
   defp convert_formatter_for_nif(:bbcode_scoped, _opts) do

--- a/packages/elixir/lumis/lib/lumis.ex
+++ b/packages/elixir/lumis/lib/lumis.ex
@@ -140,7 +140,7 @@ defmodule Lumis do
       - `:theme` (`t:theme/0` - default: `nil`) - the theme to apply styles on the highlighted source code.
       - `:background` (`:theme | t:String.t/0 | nil` - default: `nil`) - fallback background behavior: `nil` inherits the output background, `:theme` uses the theme's normal background color, and a string uses that color.
       - `:width` (`pos_integer() | nil` - default: `nil`) - pad each rendered terminal line to the given width. This is most useful with `:background`.
-      - `:rainbow_brackets` (`t:boolean/0` | `%Lumis.RainbowBrackets{}` - default: `false`) - when `true`, color nested brackets with a default palette. Pass a `%Lumis.RainbowBrackets{}` struct to customize colors.
+      - `:rainbow_brackets` (`t:boolean/0` | `%Lumis.RainbowBrackets{}` - default: `false`) - when `true`, color nested brackets with the selected theme's rainbow delimiter colors when available. Pass a `%Lumis.RainbowBrackets{}` struct to customize colors.
 
   * `bbcode_scoped`:
 
@@ -1012,8 +1012,8 @@ defmodule Lumis do
 
     rainbow_brackets =
       case opts[:rainbow_brackets] do
-        true -> Lumis.RainbowBrackets.new()
-        %Lumis.RainbowBrackets{} = rb -> rb
+        true -> :theme
+        %Lumis.RainbowBrackets{} = rb -> {:custom, rb}
         false -> nil
         nil -> nil
       end

--- a/packages/elixir/lumis/lib/lumis/rainbow_brackets.ex
+++ b/packages/elixir/lumis/lib/lumis/rainbow_brackets.ex
@@ -1,0 +1,51 @@
+defmodule Lumis.RainbowBrackets do
+  @moduledoc """
+  Configuration for rainbow bracket highlighting in the terminal formatter.
+
+  Rainbow brackets color nested bracket pairs `()`, `[]`, `{}`, `<>` with a
+  cycling palette based on nesting depth, making it easier to visually match
+  opening and closing delimiters.
+
+  ## Default palette
+
+      colors: ["#e06c75", "#61afef", "#98c379", "#e5c07b", "#c678dd", "#56b6c2"]
+
+  ## Example
+
+      # Use defaults
+      {:terminal, theme: "dracula", rainbow_brackets: true}
+
+      # Custom colors
+      {:terminal, theme: "dracula",
+       rainbow_brackets: %Lumis.RainbowBrackets{colors: ["#ff0000", "#00ff00", "#0000ff"]}}
+  """
+
+  @enforce_keys [:colors]
+  defstruct [:colors]
+
+  @default_colors [
+    "#e06c75",
+    "#61afef",
+    "#98c379",
+    "#e5c07b",
+    "#c678dd",
+    "#56b6c2"
+  ]
+
+  @type t :: %__MODULE__{
+          colors: [String.t()]
+        }
+
+  @doc """
+  Returns a `%Lumis.RainbowBrackets{}` with the default 6-color palette.
+  """
+  @spec new() :: t()
+  def new, do: %__MODULE__{colors: @default_colors}
+
+  @doc """
+  Returns a `%Lumis.RainbowBrackets{}` with the given custom colors.
+  """
+  @spec new([String.t()]) :: t()
+  def new([]), do: raise(ArgumentError, "Lumis.RainbowBrackets requires at least one color")
+  def new(colors) when is_list(colors), do: %__MODULE__{colors: colors}
+end

--- a/packages/elixir/lumis/lib/lumis/rainbow_brackets.ex
+++ b/packages/elixir/lumis/lib/lumis/rainbow_brackets.ex
@@ -8,7 +8,9 @@ defmodule Lumis.RainbowBrackets do
 
   ## Default palette
 
-      colors: ["#e06c75", "#61afef", "#98c379", "#e5c07b", "#c678dd", "#56b6c2"]
+  `rainbow_brackets: true` uses the selected theme's standard rainbow delimiter
+  colors when available. `%Lumis.RainbowBrackets{}` customizes the explicit
+  color palette.
 
   ## Example
 
@@ -23,24 +25,9 @@ defmodule Lumis.RainbowBrackets do
   @enforce_keys [:colors]
   defstruct [:colors]
 
-  @default_colors [
-    "#e06c75",
-    "#61afef",
-    "#98c379",
-    "#e5c07b",
-    "#c678dd",
-    "#56b6c2"
-  ]
-
   @type t :: %__MODULE__{
           colors: [String.t()]
         }
-
-  @doc """
-  Returns a `%Lumis.RainbowBrackets{}` with the default 6-color palette.
-  """
-  @spec new() :: t()
-  def new, do: %__MODULE__{colors: @default_colors}
 
   @doc """
   Returns a `%Lumis.RainbowBrackets{}` with the given custom colors.

--- a/packages/elixir/lumis/native/lumis_nif/src/elixir.rs
+++ b/packages/elixir/lumis/native/lumis_nif/src/elixir.rs
@@ -48,18 +48,10 @@ pub enum ExFormatterOption {
     BbcodeScoped {},
 }
 
-#[derive(Clone, Debug, NifStruct)]
+#[derive(Clone, Debug, Default, NifStruct)]
 #[module = "Lumis.RainbowBrackets"]
 pub struct ExRainbowBrackets {
     pub colors: Vec<String>,
-}
-
-impl Default for ExRainbowBrackets {
-    fn default() -> Self {
-        Self {
-            colors: vec![],
-        }
-    }
 }
 
 #[derive(Debug, NifTaggedEnum)]

--- a/packages/elixir/lumis/native/lumis_nif/src/elixir.rs
+++ b/packages/elixir/lumis/native/lumis_nif/src/elixir.rs
@@ -1,10 +1,11 @@
 use lumis::formatters::{
     html_inline, html_linked, BBCodeScopedBuilder, Formatter, HtmlElement, HtmlInlineBuilder,
-    HtmlLinkedBuilder, HtmlMultiThemesBuilder, TerminalBackground, TerminalBuilder,
+    HtmlLinkedBuilder, HtmlMultiThemesBuilder, RainbowBrackets, TerminalBackground, TerminalBuilder,
 };
 use lumis::{languages::Language, themes};
 use rustler::{NifStruct, NifTaggedEnum, NifUnitEnum};
 use std::collections::HashMap;
+use std::sync::Arc;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, NifUnitEnum)]
 pub enum ExAppearance {
@@ -42,8 +43,23 @@ pub enum ExFormatterOption {
         theme: Option<ThemeOrString>,
         background: Option<ExTerminalBackground>,
         width: Option<usize>,
+        rainbow_brackets: Option<ExRainbowBrackets>,
     },
     BbcodeScoped {},
+}
+
+#[derive(Clone, Debug, NifStruct)]
+#[module = "Lumis.RainbowBrackets"]
+pub struct ExRainbowBrackets {
+    pub colors: Vec<String>,
+}
+
+impl Default for ExRainbowBrackets {
+    fn default() -> Self {
+        Self {
+            colors: vec![],
+        }
+    }
 }
 
 #[derive(Debug, NifTaggedEnum)]
@@ -215,6 +231,7 @@ impl ExFormatterOption {
                 theme,
                 background,
                 width,
+                rainbow_brackets,
             } => {
                 let theme = theme.and_then(resolve_theme);
                 let background = match background {
@@ -230,6 +247,13 @@ impl ExFormatterOption {
                     .width(width)
                     .build()
                     .map_err(|e| format!("Terminal builder error: {:?}", e))?;
+
+                let formatter = match rainbow_brackets {
+                    Some(rb) => {
+                        formatter.with_style_override(Arc::new(RainbowBrackets::new(rb.colors)))
+                    }
+                    None => formatter,
+                };
 
                 Ok(Box::new(formatter))
             }

--- a/packages/elixir/lumis/native/lumis_nif/src/elixir.rs
+++ b/packages/elixir/lumis/native/lumis_nif/src/elixir.rs
@@ -43,7 +43,7 @@ pub enum ExFormatterOption {
         theme: Option<ThemeOrString>,
         background: Option<ExTerminalBackground>,
         width: Option<usize>,
-        rainbow_brackets: Option<ExRainbowBrackets>,
+        rainbow_brackets: Option<ExRainbowBracketsOption>,
     },
     BbcodeScoped {},
 }
@@ -52,6 +52,12 @@ pub enum ExFormatterOption {
 #[module = "Lumis.RainbowBrackets"]
 pub struct ExRainbowBrackets {
     pub colors: Vec<String>,
+}
+
+#[derive(Clone, Debug, NifTaggedEnum)]
+pub enum ExRainbowBracketsOption {
+    Theme,
+    Custom(ExRainbowBrackets),
 }
 
 #[derive(Debug, NifTaggedEnum)]
@@ -241,7 +247,9 @@ impl ExFormatterOption {
                     .map_err(|e| format!("Terminal builder error: {:?}", e))?;
 
                 let formatter = match rainbow_brackets {
-                    Some(rb) => {
+                    Some(ExRainbowBracketsOption::Theme) => formatter
+                        .with_style_override(RainbowBrackets::from_theme(theme.as_ref()).into_override()),
+                    Some(ExRainbowBracketsOption::Custom(rb)) => {
                         formatter.with_style_override(Arc::new(RainbowBrackets::new(rb.colors)))
                     }
                     None => formatter,

--- a/packages/elixir/lumis/test/lumis_test.exs
+++ b/packages/elixir/lumis/test/lumis_test.exs
@@ -168,7 +168,13 @@ defmodule Lumis.LumisTest do
       assert {:ok, {:terminal, formatter_opts}} = Lumis.formatter_type(:terminal)
 
       assert Keyword.equal?(
-               [language: nil, theme: "onedark", background: nil, width: nil],
+               [
+                 language: nil,
+                 theme: "onedark",
+                 background: nil,
+                 width: nil,
+                 rainbow_brackets: nil
+               ],
                formatter_opts
              )
     end

--- a/themes/astrodark.json
+++ b/themes/astrodark.json
@@ -315,6 +315,27 @@
     "punctuation.special.rust": {
       "fg": "#dd97f1"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#5eb7ff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#4ac2b8"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#87c05f"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f5983a"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ff838b"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#dd97f1"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#dfab25"
+    },
     "string": {
       "fg": "#87c05f"
     },

--- a/themes/astrojupiter.json
+++ b/themes/astrojupiter.json
@@ -315,6 +315,27 @@
     "punctuation.special.rust": {
       "fg": "#90437a"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#006e89"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#007652"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#467118"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#954d00"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#a13f37"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#90437a"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#805c00"
+    },
     "string": {
       "fg": "#467118"
     },

--- a/themes/astrolight.json
+++ b/themes/astrolight.json
@@ -315,6 +315,27 @@
     "punctuation.special.rust": {
       "fg": "#9e007c"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#00508a"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#00615b"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#345e00"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#a34500"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#990000"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#9e007c"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#7300b8"
+    },
     "string": {
       "fg": "#345e00"
     },

--- a/themes/astromars.json
+++ b/themes/astromars.json
@@ -315,6 +315,27 @@
     "punctuation.special.rust": {
       "fg": "#cd87ba"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#4fa9c6"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#4fad97"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#84a860"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ef9474"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#df8489"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#cd87ba"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#c3963d"
+    },
     "string": {
       "fg": "#84a860"
     },

--- a/themes/bamboo_light.json
+++ b/themes/bamboo_light.json
@@ -290,6 +290,27 @@
     "punctuation.special.diff": {
       "fg": "#838781"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#1134a0"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#126877"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#1d6408"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#a7431d"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#95202d"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6838a7"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#7d5c00"
+    },
     "string": {
       "fg": "#27850b"
     },

--- a/themes/bamboo_multiplex.json
+++ b/themes/bamboo_multiplex.json
@@ -290,6 +290,27 @@
     "punctuation.special.diff": {
       "fg": "#818781"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#70b5e5"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#8ecbc2"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a1c382"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f3b374"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#e57b89"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#b8b3fa"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#dacb77"
+    },
     "string": {
       "fg": "#81af58"
     },

--- a/themes/bamboo_vulgaris.json
+++ b/themes/bamboo_vulgaris.json
@@ -290,6 +290,27 @@
     "punctuation.special.diff": {
       "fg": "#838781"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#81bcec"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#94d1ce"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#abc896"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ffb38c"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ed839d"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#bfbfff"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e4c87d"
+    },
     "string": {
       "fg": "#8fb573"
     },

--- a/themes/bluloco_dark.json
+++ b/themes/bluloco_dark.json
@@ -246,6 +246,27 @@
     "punctuation.special": {
       "fg": "#7c84da"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#42a4ff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#28e5eb"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#91f532"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ffa024"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ff6666"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#ff7aff"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f4ff7a"
+    },
     "string": {
       "fg": "#f9c958"
     },

--- a/themes/bluloco_light.json
+++ b/themes/bluloco_light.json
@@ -246,6 +246,27 @@
     "punctuation.special": {
       "fg": "#7c84da"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#0ab6ff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#0e92aa"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#1fc155"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ffa024"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f066f0"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#a557ff"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#b1b800"
+    },
     "string": {
       "fg": "#c4a231"
     },

--- a/themes/carbonfox.json
+++ b/themes/carbonfox.json
@@ -258,6 +258,24 @@
     "punctuation.special": {
       "fg": "#52bdff"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#78a9ff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#33b1ff"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#25be6a"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#3ddbd9"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ee5396"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#08bdba"
+    },
     "string": {
       "fg": "#25be6a"
     },

--- a/themes/catppuccin_frappe.json
+++ b/themes/catppuccin_frappe.json
@@ -344,6 +344,27 @@
     "punctuation.special": {
       "fg": "#f4b8e4"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#8caaee"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#81c8be"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a6d189"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ef9f76"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#e78284"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#ca9ee6"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e5c890"
+    },
     "string": {
       "fg": "#a6d189"
     },

--- a/themes/catppuccin_latte.json
+++ b/themes/catppuccin_latte.json
@@ -344,6 +344,27 @@
     "punctuation.special": {
       "fg": "#ea76cb"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#1e66f5"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#179299"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#40a02b"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#fe640b"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#d20f39"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#8839ef"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#df8e1d"
+    },
     "string": {
       "fg": "#40a02b"
     },

--- a/themes/catppuccin_macchiato.json
+++ b/themes/catppuccin_macchiato.json
@@ -344,6 +344,27 @@
     "punctuation.special": {
       "fg": "#f5bde6"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#8aadf4"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#8bd5ca"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a6da95"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f5a97f"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ed8796"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#c6a0f6"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#eed49f"
+    },
     "string": {
       "fg": "#a6da95"
     },

--- a/themes/catppuccin_mocha.json
+++ b/themes/catppuccin_mocha.json
@@ -344,6 +344,27 @@
     "punctuation.special": {
       "fg": "#f5c2e7"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#89b4fa"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#94e2d5"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a6e3a1"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#fab387"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f38ba8"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#cba6f7"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f9e2af"
+    },
     "string": {
       "fg": "#a6e3a1"
     },

--- a/themes/citruszest.json
+++ b/themes/citruszest.json
@@ -285,6 +285,27 @@
     "punctuation.special": {
       "fg": "#ffaa54"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#00bfff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#33ffff"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#1affa3"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ff7431"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ff1a75"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#af74ee"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ffff00"
+    },
     "string": {
       "fg": "#b2f3ac"
     },

--- a/themes/cyberdream_dark.json
+++ b/themes/cyberdream_dark.json
@@ -257,6 +257,27 @@
     "punctuation.special": {
       "fg": "#ffffff"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#5ea1ff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#5ef1ff"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#5eff6c"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ffbd5e"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ff6e5e"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#bd5eff"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f1ff5e"
+    },
     "string": {
       "fg": "#5eff6c"
     },

--- a/themes/cyberdream_light.json
+++ b/themes/cyberdream_light.json
@@ -257,6 +257,27 @@
     "punctuation.special": {
       "fg": "#16181a"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#0057d1"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#008c99"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#008b0c"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d17c00"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#d11500"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#a018ff"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#997b00"
+    },
     "string": {
       "fg": "#008b0c"
     },

--- a/themes/dawnfox.json
+++ b/themes/dawnfox.json
@@ -258,6 +258,24 @@
     "punctuation.special": {
       "fg": "#50848c"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#286983"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#56949f"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#618774"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d7827e"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#b4637a"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ea9d34"
+    },
     "string": {
       "fg": "#618774"
     },

--- a/themes/dayfox.json
+++ b/themes/dayfox.json
@@ -258,6 +258,24 @@
     "punctuation.special": {
       "fg": "#22676d"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#2848a9"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#287980"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#396847"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#955f61"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#a5222f"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ac5402"
+    },
     "string": {
       "fg": "#396847"
     },

--- a/themes/deepwhite.json
+++ b/themes/deepwhite.json
@@ -269,6 +269,27 @@
     "punctuation.special": {
       "fg": "#0000a6"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#0000a6"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#00a6a6"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#00a600"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f27900"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#a60000"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6f00a6"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f2f200"
+    },
     "string": {
       "fg": "#1a1918",
       "bg": "#d4fad4"

--- a/themes/dracula.json
+++ b/themes/dracula.json
@@ -276,6 +276,27 @@
       "fg": "#50fa7b",
       "italic": true
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#8be9fd"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#f8f8f2"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#bd93f9"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#50fa7b"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f8f8f2"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#ffb86c"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ff79c6"
+    },
     "string": {
       "fg": "#f1fa8c"
     },

--- a/themes/dracula_soft.json
+++ b/themes/dracula_soft.json
@@ -276,6 +276,27 @@
       "fg": "#87e58e",
       "italic": true
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#a7dfef"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#f6f6f5"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#baa0e8"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#87e58e"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f6f6f5"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#fdc38e"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e48cc1"
+    },
     "string": {
       "fg": "#e8eda2"
     },

--- a/themes/duskfox.json
+++ b/themes/duskfox.json
@@ -258,6 +258,24 @@
     "punctuation.special": {
       "fg": "#a6dae3"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#569fba"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#9ccfd8"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a3be8c"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ea9a97"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#eb6f92"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f6c177"
+    },
     "string": {
       "fg": "#a3be8c"
     },

--- a/themes/edge_aura.json
+++ b/themes/edge_aura.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#deb974"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#6cb6eb"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#5dbbc1"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a0c980"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d38aea"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ec7279"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#d38aea"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#deb974"
+    },
     "string": {
       "fg": "#a0c980"
     },

--- a/themes/edge_dark.json
+++ b/themes/edge_dark.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#deb974"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#6cb6eb"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#5dbbc1"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a0c980"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d38aea"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ec7279"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#d38aea"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#deb974"
+    },
     "string": {
       "fg": "#a0c980"
     },

--- a/themes/edge_light.json
+++ b/themes/edge_light.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#be7e05"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#5079be"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#3a8b84"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#608e32"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#b05ccc"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#d05858"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#b05ccc"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#be7e05"
+    },
     "string": {
       "fg": "#608e32"
     },

--- a/themes/edge_neon.json
+++ b/themes/edge_neon.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#deb974"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#6cb6eb"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#5dbbc1"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a0c980"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d38aea"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ec7279"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#d38aea"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#deb974"
+    },
     "string": {
       "fg": "#a0c980"
     },

--- a/themes/eldritch.json
+++ b/themes/eldritch.json
@@ -274,6 +274,27 @@
     "punctuation.special": {
       "fg": "#04d1f9"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#04d1f9"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#10a1bd"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a48cf2"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f7c67f"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f16c75"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#37f499"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f1fc79"
+    },
     "string": {
       "fg": "#f1fc79"
     },

--- a/themes/everforest_dark.json
+++ b/themes/everforest_dark.json
@@ -325,6 +325,27 @@
     "punctuation.special.typescript": {
       "fg": "#e69875"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#7fbbb3"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#83c092"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a7c080"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#e69875"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#e67e80"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#d699b6"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#dbbc7f"
+    },
     "string": {
       "fg": "#83c092"
     },

--- a/themes/everforest_light.json
+++ b/themes/everforest_light.json
@@ -325,6 +325,27 @@
     "punctuation.special.typescript": {
       "fg": "#f57d26"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#3a94c5"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#35a77c"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#8da101"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f57d26"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f85552"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#df69ba"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#dfa000"
+    },
     "string": {
       "fg": "#35a77c"
     },

--- a/themes/extract_theme.lua
+++ b/themes/extract_theme.lua
@@ -15,7 +15,7 @@ local function plugin_dir_name(repo_url)
 	if not repo then
 		return "unknown"
 	end
-	if owner and colliding_repo_names[repo] then
+	if owner and colliding_repo_names[string.lower(repo)] then
 		return owner .. "-" .. repo
 	end
 	return repo
@@ -33,6 +33,16 @@ local regular_groups = {
 	"Normal",
 	"Comment",
 	"CursorLine",
+}
+
+local rainbow_delimiter_groups = {
+	"RainbowDelimiterRed",
+	"RainbowDelimiterYellow",
+	"RainbowDelimiterBlue",
+	"RainbowDelimiterOrange",
+	"RainbowDelimiterGreen",
+	"RainbowDelimiterViolet",
+	"RainbowDelimiterCyan",
 }
 
 local treesitter_groups = {
@@ -328,6 +338,10 @@ local function extract_colorscheme_colors(theme)
 		table.insert(all_groups, group)
 	end
 
+	for _, group in ipairs(rainbow_delimiter_groups) do
+		table.insert(all_groups, group)
+	end
+
 	for _, group in ipairs(treesitter_groups) do
 		table.insert(all_groups, "@" .. group)
 	end
@@ -343,6 +357,9 @@ local function extract_colorscheme_colors(theme)
 			local key = string.lower(string.gsub(group, "@", ""))
 			if key == "cursorline" then
 				key = "highlighted"
+			elseif string.sub(group, 1, string.len("RainbowDelimiter")) == "RainbowDelimiter" then
+				key = string.gsub(group, "RainbowDelimiter", "rainbow.delimiter.")
+				key = string.lower(key)
 			end
 			highlights[key] = style
 		end
@@ -442,15 +459,17 @@ local repo_names = {}
 for _, theme_def in ipairs(themes) do
 	local _, repo = parse_repo_parts(theme_def.url)
 	if repo then
-		repo_names[repo] = repo_names[repo] or {}
-		repo_names[repo][theme_def.url] = true
+		local key = string.lower(repo)
+		repo_names[key] = repo_names[key] or {}
+		repo_names[key][theme_def.url] = true
 	end
 	if theme_def.dependencies then
 		for _, dep_url in ipairs(theme_def.dependencies) do
 			local _, dep_repo = parse_repo_parts(dep_url)
 			if dep_repo then
-				repo_names[dep_repo] = repo_names[dep_repo] or {}
-				repo_names[dep_repo][dep_url] = true
+				local key = string.lower(dep_repo)
+				repo_names[key] = repo_names[key] or {}
+				repo_names[key][dep_url] = true
 			end
 		end
 	end

--- a/themes/gruber_darker.json
+++ b/themes/gruber_darker.json
@@ -264,6 +264,27 @@
     "punctuation.special": {
       "fg": "#cc8c3c"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#96a6c8"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#95a99f"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#73d936"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cc8c3c"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ff4f58"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#9e95c7"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ffdd33"
+    },
     "string": {
       "fg": "#73d936",
       "italic": true

--- a/themes/gruvbox_dark.json
+++ b/themes/gruvbox_dark.json
@@ -262,6 +262,27 @@
     "punctuation.special": {
       "fg": "#fe8019"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#83a598"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#8ec07c"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#b8bb26"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#fe8019"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#fb4934"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#d3869b"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#fabd2f"
+    },
     "string": {
       "fg": "#b8bb26",
       "italic": true

--- a/themes/gruvbox_dark_hard.json
+++ b/themes/gruvbox_dark_hard.json
@@ -262,6 +262,27 @@
     "punctuation.special": {
       "fg": "#fe8019"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#83a598"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#8ec07c"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#b8bb26"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#fe8019"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#fb4934"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#d3869b"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#fabd2f"
+    },
     "string": {
       "fg": "#b8bb26",
       "italic": true

--- a/themes/gruvbox_dark_soft.json
+++ b/themes/gruvbox_dark_soft.json
@@ -262,6 +262,27 @@
     "punctuation.special": {
       "fg": "#fe8019"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#83a598"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#8ec07c"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#b8bb26"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#fe8019"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#fb4934"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#d3869b"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#fabd2f"
+    },
     "string": {
       "fg": "#b8bb26",
       "italic": true

--- a/themes/gruvbox_light.json
+++ b/themes/gruvbox_light.json
@@ -262,6 +262,27 @@
     "punctuation.special": {
       "fg": "#af3a03"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#076678"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#427b58"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#79740e"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#af3a03"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#9d0006"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#8f3f71"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#b57614"
+    },
     "string": {
       "fg": "#79740e",
       "italic": true

--- a/themes/gruvbox_light_hard.json
+++ b/themes/gruvbox_light_hard.json
@@ -262,6 +262,27 @@
     "punctuation.special": {
       "fg": "#af3a03"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#076678"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#427b58"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#79740e"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#af3a03"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#9d0006"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#8f3f71"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#b57614"
+    },
     "string": {
       "fg": "#79740e",
       "italic": true

--- a/themes/gruvbox_light_soft.json
+++ b/themes/gruvbox_light_soft.json
@@ -262,6 +262,27 @@
     "punctuation.special": {
       "fg": "#af3a03"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#076678"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#427b58"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#79740e"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#af3a03"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#9d0006"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#8f3f71"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#b57614"
+    },
     "string": {
       "fg": "#79740e",
       "italic": true

--- a/themes/gruvbox_material_dark.json
+++ b/themes/gruvbox_material_dark.json
@@ -301,6 +301,27 @@
     "punctuation.special.typescript": {
       "fg": "#e78a4e"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#7daea3"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#89b482"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a9b665"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#e78a4e"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ea6962"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#d3869b"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#d8a657"
+    },
     "string": {
       "fg": "#89b482"
     },

--- a/themes/gruvbox_material_light.json
+++ b/themes/gruvbox_material_light.json
@@ -301,6 +301,27 @@
     "punctuation.special.typescript": {
       "fg": "#c35e0a"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#45707a"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#4c7a5d"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#6c782e"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c35e0a"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#c14a4a"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#945e80"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#b47109"
+    },
     "string": {
       "fg": "#4c7a5d"
     },

--- a/themes/horizon_dark.json
+++ b/themes/horizon_dark.json
@@ -252,6 +252,27 @@
     "punctuation.special": {
       "fg": "#6c6d71"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#169fff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#25b0bc"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#29d398"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#db887a"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#d55070"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#a86ec9"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e4b28e"
+    },
     "string": {
       "fg": "#e4a88a"
     },

--- a/themes/horizon_light.json
+++ b/themes/horizon_light.json
@@ -227,6 +227,27 @@
     "punctuation.special": {
       "fg": "#333333"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#169fff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#1d8991"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#29d398"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#dc3318"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#da103f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#8a31b9"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f77d26"
+    },
     "string": {
       "fg": "#f6661e"
     },

--- a/themes/kanagawa_paper_dark.json
+++ b/themes/kanagawa_paper_dark.json
@@ -248,6 +248,27 @@
     "punctuation.special": {
       "fg": "#c4746e"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#658594"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#949fb5"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#699469"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#9d7665"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#c4746e"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#737c73"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#a292a3"
+    },
     "string": {
       "fg": "#8a9a7b"
     },

--- a/themes/kanagawa_paper_light.json
+++ b/themes/kanagawa_paper_light.json
@@ -248,6 +248,27 @@
     "punctuation.special": {
       "fg": "#c27672"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#809ba7"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#7e8faf"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#7e9579"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#a8826a"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#c27672"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#637263"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#9e7e98"
+    },
     "string": {
       "fg": "#7e9579"
     },

--- a/themes/lackluster.json
+++ b/themes/lackluster.json
@@ -247,6 +247,27 @@
     "punctuation.special": {
       "fg": "#7a7a7a"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#aaaaaa"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#dddddd"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#666666"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cccccc"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#555555"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#bbbbbb"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#999999"
+    },
     "string": {
       "fg": "#708090"
     },

--- a/themes/lackluster_hack.json
+++ b/themes/lackluster_hack.json
@@ -247,6 +247,27 @@
     "punctuation.special": {
       "fg": "#7a7a7a"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#aaaaaa"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#dddddd"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#666666"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cccccc"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#555555"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#bbbbbb"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#999999"
+    },
     "string": {
       "fg": "#708090"
     },

--- a/themes/lackluster_mint.json
+++ b/themes/lackluster_mint.json
@@ -247,6 +247,27 @@
     "punctuation.special": {
       "fg": "#7a7a7a"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#aaaaaa"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#dddddd"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#666666"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cccccc"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#555555"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#bbbbbb"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#999999"
+    },
     "string": {
       "fg": "#708090"
     },

--- a/themes/melange_dark.json
+++ b/themes/melange_dark.json
@@ -250,6 +250,27 @@
     "punctuation.special": {
       "fg": "#ebc06d"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#a3a9ce"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#89b3b6"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#85b695"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#e49b5d"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#d47766"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#b380b0"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ebc06d"
+    },
     "string": {
       "fg": "#a3a9ce",
       "italic": true

--- a/themes/melange_light.json
+++ b/themes/melange_light.json
@@ -250,6 +250,27 @@
     "punctuation.special": {
       "fg": "#a06d00"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#465aa4"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#3d6568"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#3a684a"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#bc5c00"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#bf0021"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#be79bb"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#a06d00"
+    },
     "string": {
       "fg": "#465aa4",
       "italic": true

--- a/themes/modus_operandi.json
+++ b/themes/modus_operandi.json
@@ -256,6 +256,27 @@
     "punctuation.special": {
       "fg": "#000000"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#0031a9"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#005e8b"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#006800"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#884900"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#a60000"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#531ab6"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#6f5500"
+    },
     "string": {
       "fg": "#3548cf"
     },

--- a/themes/modus_vivendi.json
+++ b/themes/modus_vivendi.json
@@ -256,6 +256,27 @@
     "punctuation.special": {
       "fg": "#ffffff"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#2fafff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#00d3d0"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#44bc44"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#fec43f"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ff5f59"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#b6a0ff"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#d0bc00"
+    },
     "string": {
       "fg": "#79a8ff"
     },

--- a/themes/monokai_nightasty_dark.json
+++ b/themes/monokai_nightasty_dark.json
@@ -257,6 +257,27 @@
     "punctuation.special": {
       "fg": "#fc1a70"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#0087ff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#62d8f1"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a4e400"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ff9700"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#fc1a70"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#af87ff"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ffff87"
+    },
     "string": {
       "fg": "#ffff87"
     },

--- a/themes/monokai_nightasty_light.json
+++ b/themes/monokai_nightasty_light.json
@@ -257,6 +257,27 @@
     "punctuation.special": {
       "fg": "#ff004b"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#0087ff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#00b3e3"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#4fb000"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ff4d00"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ff004b"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6054d0"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ff8f00"
+    },
     "string": {
       "fg": "#ff8f00"
     },

--- a/themes/moonfly.json
+++ b/themes/moonfly.json
@@ -320,6 +320,27 @@
     "punctuation.special": {
       "fg": "#e65e72"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#80a0ff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#79dac8"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#8cc85f"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#de935f"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ff5d5d"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#cf87e8"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e3c78a"
+    },
     "string": {
       "fg": "#c6c684"
     },

--- a/themes/neofusion.json
+++ b/themes/neofusion.json
@@ -262,6 +262,27 @@
     "punctuation.special": {
       "fg": "#fd5e3a"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#35b5ff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#66def9"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#008da3"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#fa7a61"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#fd5e3a"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#fd5e3a"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e2d9c5"
+    },
     "string": {
       "fg": "#35b5ff",
       "italic": true

--- a/themes/night_owl.json
+++ b/themes/night_owl.json
@@ -347,6 +347,15 @@
     "punctuation.special.bash": {
       "fg": "#c5e478"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#169fff"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#da70d6"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ffd602"
+    },
     "string": {
       "fg": "#ecc48d"
     },

--- a/themes/nightfly.json
+++ b/themes/nightfly.json
@@ -320,6 +320,27 @@
     "punctuation.special": {
       "fg": "#ff5874"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#82aaff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#7fdbca"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a1cd5e"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f78c6c"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#fc514e"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#c792ea"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e3d18a"
+    },
     "string": {
       "fg": "#ecc48d"
     },

--- a/themes/nightfox.json
+++ b/themes/nightfox.json
@@ -258,6 +258,24 @@
     "punctuation.special": {
       "fg": "#7ad5d6"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#719cd6"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#63cdcf"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#81b29a"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f4a261"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#c94f6d"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#dbc074"
+    },
     "string": {
       "fg": "#81b29a"
     },

--- a/themes/nord.json
+++ b/themes/nord.json
@@ -284,6 +284,27 @@
     "punctuation.special": {
       "fg": "#88c0d0"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#81a1c1"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#88c0d0"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a3be8c"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d08770"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#bf616a"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#b48ead"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ebcb8b"
+    },
     "string": {
       "fg": "#a3be8c",
       "italic": true

--- a/themes/nordfox.json
+++ b/themes/nordfox.json
@@ -258,6 +258,24 @@
     "punctuation.special": {
       "fg": "#93ccdc"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#81a1c1"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#88c0d0"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a3be8c"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c9826b"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#bf616a"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ebcb8b"
+    },
     "string": {
       "fg": "#a3be8c"
     },

--- a/themes/nordic.json
+++ b/themes/nordic.json
@@ -255,6 +255,21 @@
       "fg": "#d08770",
       "bold": true
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#88c0d0"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#b1c89d"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d08770"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#c5727a"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#efd49f"
+    },
     "string": {
       "fg": "#a3be8c"
     },

--- a/themes/obscure.json
+++ b/themes/obscure.json
@@ -272,6 +272,34 @@
     "punctuation.special": {
       "fg": "#b4b1ba"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#6a8cbc",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#85b5ba",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#90b99f",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c88477",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#c45570",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#8787bf",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#bc9781",
+      "bg": "#161617"
+    },
     "string": {
       "fg": "#90b99f"
     },

--- a/themes/oldworld.json
+++ b/themes/oldworld.json
@@ -256,6 +256,34 @@
     "punctuation.special": {
       "fg": "#b4b1ba"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#92a2d5",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#85b5ba",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#90b99f",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f5a191",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ea83a5",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#aca1cf",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e6b99d",
+      "bg": "#161617"
+    },
     "string": {
       "fg": "#90b99f"
     },

--- a/themes/oldworld_cooler.json
+++ b/themes/oldworld_cooler.json
@@ -256,6 +256,34 @@
     "punctuation.special": {
       "fg": "#b2b1ba"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#92b3d5",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#85bab2",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#90b995",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f5919a",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ea83bf",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#a1a1cf",
+      "bg": "#161617"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e6a79d",
+      "bg": "#161617"
+    },
     "string": {
       "fg": "#90b995"
     },

--- a/themes/oldworld_oled.json
+++ b/themes/oldworld_oled.json
@@ -256,6 +256,34 @@
     "punctuation.special": {
       "fg": "#b4b1ba"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#92a2d5",
+      "bg": "#000000"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#85b5ba",
+      "bg": "#000000"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#90b99f",
+      "bg": "#000000"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f5a191",
+      "bg": "#000000"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ea83a5",
+      "bg": "#000000"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#aca1cf",
+      "bg": "#000000"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e6b99d",
+      "bg": "#000000"
+    },
     "string": {
       "fg": "#90b99f"
     },

--- a/themes/one_monokai.json
+++ b/themes/one_monokai.json
@@ -243,6 +243,27 @@
     "punctuation.special": {
       "fg": "#c678dd"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#61afef"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#56b6c2"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#98c379"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d19a66"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#d03770"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#c678dd"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e5c07b"
+    },
     "string": {
       "fg": "#e5c07b"
     },

--- a/themes/onedark.json
+++ b/themes/onedark.json
@@ -392,6 +392,27 @@
     "punctuation.special.markdown": {
       "fg": "#7f848e"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#61afef"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#56b6c2"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#98c379"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d19a66"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#e06c75"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#c678dd"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e5c07b"
+    },
     "string": {
       "fg": "#98c379"
     },

--- a/themes/onedark_cool.json
+++ b/themes/onedark_cool.json
@@ -258,6 +258,27 @@
     "punctuation.special": {
       "fg": "#ef5f6b"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#5ab0f6"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#4dbdcb"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#97ca72"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d99a5e"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ef5f6b"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#ca72e4"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ebc275"
+    },
     "string": {
       "fg": "#97ca72"
     },

--- a/themes/onedark_darker.json
+++ b/themes/onedark_darker.json
@@ -258,6 +258,27 @@
     "punctuation.special": {
       "fg": "#e55561"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#4fa6ed"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#48b0bd"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#8ebd6b"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cc9057"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#e55561"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#bf68d9"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e2b86b"
+    },
     "string": {
       "fg": "#8ebd6b"
     },

--- a/themes/onedark_deep.json
+++ b/themes/onedark_deep.json
@@ -258,6 +258,27 @@
     "punctuation.special": {
       "fg": "#f65866"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#41a7fc"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#34bfd0"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#8bcd5b"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#dd9046"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f65866"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#c75ae8"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#efbd5d"
+    },
     "string": {
       "fg": "#8bcd5b"
     },

--- a/themes/onedark_light.json
+++ b/themes/onedark_light.json
@@ -258,6 +258,27 @@
     "punctuation.special": {
       "fg": "#e45649"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#4078f2"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#0184bc"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#50a14f"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c18401"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#e45649"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#a626a4"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#986801"
+    },
     "string": {
       "fg": "#50a14f"
     },

--- a/themes/onedark_warm.json
+++ b/themes/onedark_warm.json
@@ -258,6 +258,27 @@
     "punctuation.special": {
       "fg": "#e16d77"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#68aee8"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#5fafb9"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#99bc80"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c99a6e"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#e16d77"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#c27fd7"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#dfbe81"
+    },
     "string": {
       "fg": "#99bc80"
     },

--- a/themes/onedark_warmer.json
+++ b/themes/onedark_warmer.json
@@ -258,6 +258,27 @@
     "punctuation.special": {
       "fg": "#de5d68"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#57a5e5"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#51a8b3"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#8fb573"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c49060"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#de5d68"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#bb70d2"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#dbb671"
+    },
     "string": {
       "fg": "#8fb573"
     },

--- a/themes/onedarkpro_dark.json
+++ b/themes/onedarkpro_dark.json
@@ -392,6 +392,27 @@
     "punctuation.special.markdown": {
       "fg": "#7f848e"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#61afef"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#2bbac5"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#89ca78"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d19a66"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ef596f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#d55fde"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e5c07b"
+    },
     "string": {
       "fg": "#89ca78"
     },

--- a/themes/onedarkpro_vivid.json
+++ b/themes/onedarkpro_vivid.json
@@ -392,6 +392,27 @@
     "punctuation.special.markdown": {
       "fg": "#7f848e"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#61afef"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#2bbac5"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#89ca78"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d19a66"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ef596f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#d55fde"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e5c07b"
+    },
     "string": {
       "fg": "#89ca78"
     },

--- a/themes/onelight.json
+++ b/themes/onelight.json
@@ -392,6 +392,27 @@
     "punctuation.special.markdown": {
       "fg": "#9b9fa6"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#118dc3"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#56b6c2"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#1da912"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ee9025"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#e05661"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#9a77cf"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#eea825"
+    },
     "string": {
       "fg": "#1da912"
     },

--- a/themes/rosepine_dark.json
+++ b/themes/rosepine_dark.json
@@ -289,6 +289,27 @@
     "punctuation.special": {
       "fg": "#908caa"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#31748f"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#9ccfd8"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#95b1ac"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ebbcba"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#eb6f92"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#c4a7e7"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f6c177"
+    },
     "string": {
       "fg": "#f6c177"
     },

--- a/themes/rosepine_dawn.json
+++ b/themes/rosepine_dawn.json
@@ -289,6 +289,27 @@
     "punctuation.special": {
       "fg": "#797593"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#286983"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#56949f"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#6d8f89"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#d7827e"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#b4637a"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#907aa9"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ea9d34"
+    },
     "string": {
       "fg": "#ea9d34"
     },

--- a/themes/rosepine_moon.json
+++ b/themes/rosepine_moon.json
@@ -289,6 +289,27 @@
     "punctuation.special": {
       "fg": "#908caa"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#3e8fb0"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#9ccfd8"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#95b1ac"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ea9a97"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#eb6f92"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#c4a7e7"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f6c177"
+    },
     "string": {
       "fg": "#f6c177"
     },

--- a/themes/solarized_autumn_dark.json
+++ b/themes/solarized_autumn_dark.json
@@ -254,6 +254,24 @@
     "punctuation.special": {
       "fg": "#859900"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd2"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#2aa198"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#859900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cb4b16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#dc322f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6c71c4"
+    },
     "string": {
       "fg": "#2aa198"
     },

--- a/themes/solarized_autumn_light.json
+++ b/themes/solarized_autumn_light.json
@@ -255,6 +255,24 @@
     "punctuation.special": {
       "fg": "#859900"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd2"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#2aa198"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#859900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cb4b16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#dc322f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6c71c4"
+    },
     "string": {
       "fg": "#2aa198"
     },

--- a/themes/solarized_osaka_dark.json
+++ b/themes/solarized_osaka_dark.json
@@ -268,6 +268,27 @@
       "fg": "#c94c16",
       "bold": true
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd3"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#29a298"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#849900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c94c16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#db302d"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6d71c4"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#b28500"
+    },
     "string": {
       "fg": "#29a298"
     },

--- a/themes/solarized_osaka_light.json
+++ b/themes/solarized_osaka_light.json
@@ -268,6 +268,27 @@
       "fg": "#c94c16",
       "bold": true
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd3"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#29a298"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#849900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c94c16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#db302d"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6d71c4"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#b28500"
+    },
     "string": {
       "fg": "#29a298"
     },

--- a/themes/solarized_osaka_storm.json
+++ b/themes/solarized_osaka_storm.json
@@ -268,6 +268,27 @@
       "fg": "#c94c16",
       "bold": true
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd3"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#29a298"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#849900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c94c16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#db302d"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6d71c4"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#b28500"
+    },
     "string": {
       "fg": "#29a298"
     },

--- a/themes/solarized_spring_dark.json
+++ b/themes/solarized_spring_dark.json
@@ -254,6 +254,24 @@
     "punctuation.special": {
       "fg": "#859900"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd2"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#2aa198"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#859900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cb4b16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#dc322f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6c71c4"
+    },
     "string": {
       "fg": "#2aa198"
     },

--- a/themes/solarized_spring_light.json
+++ b/themes/solarized_spring_light.json
@@ -255,6 +255,24 @@
     "punctuation.special": {
       "fg": "#859900"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd2"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#2aa198"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#859900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cb4b16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#dc322f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6c71c4"
+    },
     "string": {
       "fg": "#2aa198"
     },

--- a/themes/solarized_summer_dark.json
+++ b/themes/solarized_summer_dark.json
@@ -251,6 +251,24 @@
     "punctuation.special": {
       "fg": "#859900"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd2"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#2aa198"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#859900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cb4b16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#dc322f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6c71c4"
+    },
     "string": {
       "fg": "#2aa198"
     },

--- a/themes/solarized_summer_light.json
+++ b/themes/solarized_summer_light.json
@@ -252,6 +252,24 @@
     "punctuation.special": {
       "fg": "#859900"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd2"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#2aa198"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#859900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cb4b16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#dc322f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6c71c4"
+    },
     "string": {
       "fg": "#2aa198"
     },

--- a/themes/solarized_winter_dark.json
+++ b/themes/solarized_winter_dark.json
@@ -265,6 +265,24 @@
       "fg": "#93a1a1",
       "bold": true
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd2"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#2aa198"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#859900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cb4b16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#dc322f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6c71c4"
+    },
     "string": {
       "fg": "#2aa198"
     },

--- a/themes/solarized_winter_light.json
+++ b/themes/solarized_winter_light.json
@@ -264,6 +264,24 @@
       "fg": "#586e75",
       "bold": true
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#268bd2"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#2aa198"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#859900"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#cb4b16"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#dc322f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#6c71c4"
+    },
     "string": {
       "fg": "#2aa198"
     },

--- a/themes/sonokai_andromeda.json
+++ b/themes/sonokai_andromeda.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#edc763"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#6dcae8"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#6dcae8"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#9ed06c"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f89860"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#fb617e"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#bb97ee"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#edc763"
+    },
     "string": {
       "fg": "#edc763"
     },

--- a/themes/sonokai_atlantis.json
+++ b/themes/sonokai_atlantis.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#eacb64"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#72cce8"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#72cce8"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#9dd274"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f69c5e"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ff6578"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#ba9cf3"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#eacb64"
+    },
     "string": {
       "fg": "#eacb64"
     },

--- a/themes/sonokai_default.json
+++ b/themes/sonokai_default.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#e7c664"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#76cce0"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#76cce0"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#9ed072"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f39660"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#fc5d7c"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#b39df3"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e7c664"
+    },
     "string": {
       "fg": "#e7c664"
     },

--- a/themes/sonokai_espresso.json
+++ b/themes/sonokai_espresso.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#f0c66f"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#81d0c9"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#81d0c9"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#a6cd77"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f08d71"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f86882"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#9fa0e1"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f0c66f"
+    },
     "string": {
       "fg": "#f0c66f"
     },

--- a/themes/sonokai_maia.json
+++ b/themes/sonokai_maia.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#e3d367"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#78cee9"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#78cee9"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#9cd57b"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#f3a96a"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f76c7c"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#baa0f8"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e3d367"
+    },
     "string": {
       "fg": "#e3d367"
     },

--- a/themes/sonokai_shusia.json
+++ b/themes/sonokai_shusia.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#e5c463"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#7accd7"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#7accd7"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#9ecd6f"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ef9062"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f85e84"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#ab9df2"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e5c463"
+    },
     "string": {
       "fg": "#e5c463"
     },

--- a/themes/terafox.json
+++ b/themes/terafox.json
@@ -258,6 +258,24 @@
     "punctuation.special": {
       "fg": "#afd4de"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#5a93aa"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#a1cdd8"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#7aa4a1"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ff8349"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#e85c51"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#fda47f"
+    },
     "string": {
       "fg": "#7aa4a1"
     },

--- a/themes/tokyonight_day.json
+++ b/themes/tokyonight_day.json
@@ -288,6 +288,27 @@
     "punctuation.special.markdown": {
       "fg": "#b15c00"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#2e7de9"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#007197"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#587539"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#b15c00"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f52a65"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#7847bd"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#8c6c3e"
+    },
     "string": {
       "fg": "#587539"
     },

--- a/themes/tokyonight_moon.json
+++ b/themes/tokyonight_moon.json
@@ -278,6 +278,27 @@
     "punctuation.special.markdown": {
       "fg": "#ff966c"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#82aaff"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#86e1fc"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#c3e88d"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ff966c"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#ff757f"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#fca7ea"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#ffc777"
+    },
     "string": {
       "fg": "#c3e88d"
     },

--- a/themes/tokyonight_night.json
+++ b/themes/tokyonight_night.json
@@ -288,6 +288,27 @@
     "punctuation.special.markdown": {
       "fg": "#ff9e64"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#7aa2f7"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#7dcfff"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#9ece6a"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ff9e64"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f7768e"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#9d7cd8"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e0af68"
+    },
     "string": {
       "fg": "#9ece6a"
     },

--- a/themes/tokyonight_storm.json
+++ b/themes/tokyonight_storm.json
@@ -288,6 +288,27 @@
     "punctuation.special.markdown": {
       "fg": "#ff9e64"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#7aa2f7"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#7dcfff"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#9ece6a"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ff9e64"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#f7768e"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#9d7cd8"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#e0af68"
+    },
     "string": {
       "fg": "#9ece6a"
     },

--- a/themes/vague.json
+++ b/themes/vague.json
@@ -261,6 +261,27 @@
     "punctuation.special": {
       "fg": "#6e94b2"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#7e98e8"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#6e94b2"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#7fa563"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c48282"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#d8647e"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#bb9dbd"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#f3be7c"
+    },
     "string": {
       "fg": "#e8b589",
       "italic": true

--- a/themes/vscode_dark.json
+++ b/themes/vscode_dark.json
@@ -286,6 +286,27 @@
     "punctuation.special": {
       "fg": "#d4d4d4"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#18a2fe"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#4ec9b0"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#6a9955"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#ce9178"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#c586c0"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#646695"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#d7ba7d"
+    },
     "string": {
       "fg": "#ce9178"
     },

--- a/themes/vscode_light.json
+++ b/themes/vscode_light.json
@@ -294,6 +294,27 @@
     "punctuation.special": {
       "fg": "#343434"
     },
+    "rainbow.delimiter.blue": {
+      "fg": "#18a2fe"
+    },
+    "rainbow.delimiter.cyan": {
+      "fg": "#16825d"
+    },
+    "rainbow.delimiter.green": {
+      "fg": "#008000"
+    },
+    "rainbow.delimiter.orange": {
+      "fg": "#c72e0f"
+    },
+    "rainbow.delimiter.red": {
+      "fg": "#af00db"
+    },
+    "rainbow.delimiter.violet": {
+      "fg": "#000080"
+    },
+    "rainbow.delimiter.yellow": {
+      "fg": "#800000"
+    },
     "string": {
       "fg": "#c72e0f"
     },


### PR DESCRIPTION
## Motivation

Rainbow brackets — color-coding nested delimiters by depth — is a standard feature in editors (Helix, Neovim's rainbow-delimiters.nvim, VS Code). Adding it to Lumis makes terminal output more readable for deeply nested code.

Rather than a one-off feature, this introduces a generic `StyleOverride` trait in `lumis-core` that any formatter consumer can implement. Rainbow brackets are the first concrete implementation.

## What changed

### Core: `StyleOverride` trait (`lumis-core`)

New `pub trait StyleOverride: Send + Sync + Debug` in `formatter/mod.rs`:

```rust
fn override_style(&self, text: &str, scope: &str, base: &Style, state: &mut usize) -> Style;
```

- `text` / `scope` — the token and its highlight scope name
- `base` — the style resolved from the theme
- `state` — mutable `usize` that persists across tokens (e.g. nesting depth)

The terminal formatter calls the override after resolving the theme style. Zero cost when `None` — same code path as before.

The override also fires when the theme has no style for a scope but a scope exists, so rainbow brackets work without a theme.

### Built-in: `RainbowBrackets` (`lumis-core`)

Colors `punctuation.bracket` tokens with a cycling palette based on nesting depth. Lives in `lumis-core` so all runtimes (CLI, Rust API, Elixir NIF) can use it.

### CLI: `--rainbow-brackets` flag

```bash
lumis highlight code.ex --theme dracula --rainbow-brackets
```

### Elixir: `rainbow_brackets` option

```elixir
# Default 6-color palette
Lumis.highlight!(code, formatter: {:terminal, language: "elixir", rainbow_brackets: true})

# Custom palette
Lumis.highlight!(code,
  formatter: {:terminal, language: "elixir",
    rainbow_brackets: %Lumis.RainbowBrackets{colors: ["#ff0000", "#00ff00", "#0000ff"]}}
)
```

New `Lumis.RainbowBrackets` module with `new/0` (defaults) and `new/1` (custom colors). Empty color list is rejected on both sides.

### Rust API

```rust
use lumis::formatters::RainbowBrackets;

let colors = vec!["#e06c75".into(), "#61afef".into(), "#98c379".into()];
let formatter = TerminalBuilder::new()
    .language(Language::Elixir)
    .style_override(Some(Arc::new(RainbowBrackets::new(colors))))
    .build()?;
```

### Docs

- Terminal formatter page: new "Rainbow brackets" section with Elixir/Rust/CLI examples
- CLI commands page: `--rainbow-brackets` flag and example
- Options tables updated to show current runtime availability

### Not in scope (future work)

- JavaScript / Java runtime support
- Per-language bracket config or tree-sitter query customization (these are editor-level concerns, not a highlighter library's job)

## Files changed

| Area | Files | Δ |
|------|-------|---|
| Core trait | `lumis-core/formatter/mod.rs` | +45 |
| Core terminal | `lumis-core/formatter/terminal.rs` | +38 / −16 |
| Rainbow impl | `lumis-core/formatter/rainbow_brackets.rs` (new) | ~80 |
| Rust wrapper | `lumis/formatter/terminal.rs` | +109 |
| Rust re-export | `lumis/formatter/mod.rs` | +2 |
| CLI | `lumis-cli/main.rs` | +25 |
| NIF | `lumis_nif/src/elixir.rs` | +26 |
| Elixir API | `lumis.ex` | +34 |
| Elixir module | `lumis/rainbow_brackets.ex` (new) | ~50 |
| Elixir tests | `lumis_test.exs` | +8 |
| Docs | `terminal.mdx`, `commands.mdx` | +70 |

## Test coverage

- **286 Rust tests** pass (212 `lumis` + 43 `lumis-core` + 31 `lumis-cli`)
- **5 new Rust tests**: rainbow with theme, custom colors, no override by default, works without theme, doctest
- **204 Elixir tests** pass
- `cargo fmt --check` clean
- `cargo clippy -- -D warnings` clean
- `mix format --check-formatted` clean