### PR TITLE
fix(wasm): publish grammar package types

### DIFF
--- a/crates/dev/src/main.rs
+++ b/crates/dev/src/main.rs
@@ -2168,6 +2168,11 @@ fn stage_wasm(name: &str) -> Result<()> {
     let node_entry = node_template.replace("{wasm_name}", wasm_name);
     fs::write(format!("{out}/index.node.js"), node_entry)?;
 
+    fs::copy(
+        "templates/wasm/index.d.ts.template",
+        format!("{out}/index.d.ts"),
+    )?;
+
     let readme = readme_template
         .replace("{wasm_name}", wasm_name)
         .replace("{lang}", parser_name)

--- a/templates/wasm/index.d.ts.template
+++ b/templates/wasm/index.d.ts.template
@@ -1,0 +1,2 @@
+declare const wasmBinary: Uint8Array
+export default wasmBinary

--- a/templates/wasm/package.json.template
+++ b/templates/wasm/package.json.template
@@ -2,6 +2,7 @@
   "name": "{pkg_name}",
   "version": "{npm_version}",
   "type": "module",
+  "types": "./index.d.ts",
   "description": "Tree-sitter WASM grammar for {lang}",
   "author": "Leandro Pereira",
   "license": "MIT",
@@ -12,6 +13,7 @@
   },
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "node": "./index.node.js",
       "default": "./index.js"
     },
@@ -25,5 +27,5 @@
     "treeSitter": "{tree_sitter_cli}"
   },
   "keywords": ["lumis-sh", "wasm", "tree-sitter"],
-  "files": ["*.wasm", "*.js", "README.md", "LICENSE"]
+  "files": ["*.wasm", "*.js", "*.d.ts", "README.md", "LICENSE"]
 }


### PR DESCRIPTION
## Summary
- Generate `index.d.ts` for staged `@lumis-sh/wasm-*` grammar packages.
- Expose the declaration through package `types`, export `types`, and published files.

## Verification
- `just fmt`
- `rtk cargo check --manifest-path crates/dev/Cargo.toml --no-default-features`