### PR TITLE
ci(wasm): allow forced grammar publishing

### DIFF
--- a/.github/workflows/wasm-release.yml
+++ b/.github/workflows/wasm-release.yml
@@ -29,6 +29,11 @@ on:
         description: "Parser name(s), comma-separated (leave empty for all)"
         required: false
         default: ""
+      force:
+        description: "Publish even when the current parser revision already exists"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   detect:
@@ -49,7 +54,7 @@ jobs:
       - name: Determine which parsers need publishing
         id: needed
         run: |
-          needed=$(just wasm-publish-needed "${{ inputs.parser }}")
+          needed=$(just wasm-publish-needed "${{ inputs.parser }}" "${{ inputs.force || 'false' }}")
           if [ -z "$needed" ]; then
             echo "All packages already published, nothing to build"
             echo "skip=true" >> "$GITHUB_OUTPUT"

--- a/justfile
+++ b/justfile
@@ -323,8 +323,8 @@ wasm-build name="":
     cargo run --manifest-path crates/dev/Cargo.toml -- build-wasm {{name}}
 
 # List parsers whose current WASM packages still need publishing, eg: just wasm-publish-needed bash
-wasm-publish-needed parser="":
-    @python3 scripts/wasm-needed.py "{{parser}}"
+wasm-publish-needed parser="" force="false":
+    @python3 scripts/wasm-needed.py "{{parser}}" "{{force}}"
 
 # Stage a WASM package for inspection before publishing, eg: just wasm-publish-prepare bash
 wasm-publish-prepare parser:

--- a/scripts/wasm-needed.py
+++ b/scripts/wasm-needed.py
@@ -7,7 +7,7 @@ that need a new release in the current tree-sitter CLI series.
 If a parser rev changed upstream and there is no published `0.26.x` package with
 matching `lumis.rev` metadata, the next `0.26.x` patch must be published.
 
-Usage: python3 scripts/wasm-needed.py [parser_name[,parser_name...]]
+Usage: python3 scripts/wasm-needed.py [parser_name[,parser_name...]] [force]
 """
 
 import subprocess
@@ -16,6 +16,10 @@ import tomllib
 import json
 
 SUPPORTED_TREE_SITTER_CLI = "0.26"
+
+
+def is_truthy(value: str) -> bool:
+    return value.lower() in {"1", "true", "yes", "on"}
 
 
 def wasm_package_suffix(wasm_name: str) -> str:
@@ -67,6 +71,7 @@ with open("languages.toml", "rb") as f:
 
 raw_filter = sys.argv[1] if len(sys.argv) > 1 else ""
 filter_parsers = {part.strip() for part in raw_filter.split(",") if part.strip()}
+force_publish = is_truthy(sys.argv[2]) if len(sys.argv) > 2 else False
 needed = []
 seen = set()
 
@@ -83,6 +88,10 @@ for pname, info in data.get("parsers", {}).items():
     if wasm_name in seen:
         continue
     seen.add(wasm_name)
+
+    if force_publish:
+        needed.append(wasm_name)
+        continue
 
     pkg = f"@lumis-sh/wasm-{wasm_package_suffix(wasm_name)}"
     result = subprocess.run(


### PR DESCRIPTION
## Summary
- Add a `force` workflow dispatch input for the WASM release workflow.
- Route the force flag through `just wasm-publish-needed`.
- Return the filtered parser list directly when forced, bypassing npm revision checks.

## Verification
- `just fmt`
- `python3 -m py_compile scripts/wasm-needed.py`
- `just wasm-publish-needed bash true`
- `just wasm-publish-needed "bash,css" true`