### PR TITLE
feat: add *.markdown/*.mdown/*.mkd globs to markdown

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -456,7 +456,7 @@ rev = "f969cd3ae3f9fbd4e43205431d0ae286014c05b5"
 crate = "tree-sitter-md"
 version = "0.5.3"
 location = "tree-sitter-markdown"
-globs = ["*.md", ".MD", "README", "LICENSE"]
+globs = ["*.md", "*.markdown", "*.mdown", "*.mkd", ".MD", "README", "LICENSE"]
 
 [parsers.markdown_inline]
 git = "https://github.com/tree-sitter-grammars/tree-sitter-markdown.git"


### PR DESCRIPTION
Follow-up to #1011, split out per review so it gets its own changelog entry.

Adds the common alternative markdown extensions to markdown's glob list:
`*.markdown`, `*.mdown`, `*.mkd` (the set nvim-treesitter, Helix and GitHub
linguist all map to markdown).

Regenerated outputs: none beyond the JS detection metadata build (the tracked
bundle files are unchanged; detection tables under `src/generated/` are
build-time outputs).
