### PR TITLE
fix: prevent query capture list pool overflow on large inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3112,9 +3112,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-highlight"
-version = "0.26.8"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccde2b54a34b58313e69c02496a2a9ad38d59af79b196b5e1df063431752a7e0"
+checksum = "cd7a0c48d503cf4e0a57a2453424eaef2fce4b4269f13e3579e52f0d0c9e5cc8"
 dependencies = [
  "regex",
  "streaming-iterator",

--- a/crates/lumis-cli/Cargo.toml
+++ b/crates/lumis-cli/Cargo.toml
@@ -19,7 +19,7 @@ doc = false
 
 [dependencies]
 lumis-core = { path = "../lumis-core", version = "2", features = ["all-languages"] }
-tree-sitter = { version = "^0.26", features = ["wasm"] }
+tree-sitter = { version = "^0.26.9", features = ["wasm"] }
 wasmtime = { version = "36", features = ["cache"] }
 streaming-iterator = "0.1"
 thiserror = "2"

--- a/crates/lumis/Cargo.toml
+++ b/crates/lumis/Cargo.toml
@@ -297,7 +297,7 @@ smol_str = "0.3"
 streaming-iterator = "0.1"
 termcolor = "1.4"
 thiserror = "2"
-tree-sitter = "^0.26"
+tree-sitter = "^0.26.9"
 tree-sitter-asm = { version = "0.24.0", optional = true }
 tree-sitter-arduino = { version = "0.24.0", optional = true }
 tree-sitter-bash = { version = "0.25.1", optional = true }
@@ -327,7 +327,7 @@ tree-sitter-graphql = { version = "0.1.0", optional = true }
 tree-sitter-haskell = { version = "0.23.1", optional = true }
 tree-sitter-hcl = { version = "1.1.0", optional = true }
 tree-sitter-heex = { version = "0.8.1", optional = true }
-tree-sitter-highlight = "^0.26"
+tree-sitter-highlight = "^0.26.9"
 tree-sitter-html = { version = "0.23.2", optional = true }
 tree-sitter-ini = { version = "1.4.0", optional = true }
 tree-sitter-java = { version = "0.23.5", optional = true }

--- a/crates/lumis/src/vendor/tree_sitter_highlight.rs
+++ b/crates/lumis/src/vendor/tree_sitter_highlight.rs
@@ -40,6 +40,11 @@ const CANCELLATION_CHECK_INTERVAL: usize = 100;
 const BUFFER_HTML_RESERVE_CAPACITY: usize = 10 * 1024;
 const BUFFER_LINES_RESERVE_CAPACITY: usize = 1000;
 
+// Bound the number of in-progress query matches so the capture list pool stays
+// within tree-sitter's 16-bit capture-list id space, which overflowed and
+// corrupted memory on very large inputs before tree-sitter 0.26.9.
+const MATCH_LIMIT: u32 = u16::MAX as u32;
+
 static STANDARD_CAPTURE_NAMES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     vec![
         "attribute",
@@ -578,6 +583,7 @@ impl<'a> HighlightIterLayer<'a> {
                     )
                     .ok_or(Error::Cancelled)?;
                 let mut cursor = highlighter.cursors.pop().unwrap_or_default();
+                cursor.set_match_limit(MATCH_LIMIT);
 
                 // Process combined injections.
                 if let Some(combined_injections_query) = &config.combined_injections_query {

--- a/packages/elixir/lumis/native/lumis_nif/Cargo.lock
+++ b/packages/elixir/lumis/native/lumis_nif/Cargo.lock
@@ -745,9 +745,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.8"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "887bd495d0582c5e3e0d8ece2233666169fa56a9644d172fc22ad179ab2d0538"
+checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
 dependencies = [
  "cc",
  "regex",
@@ -1049,9 +1049,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-highlight"
-version = "0.26.8"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccde2b54a34b58313e69c02496a2a9ad38d59af79b196b5e1df063431752a7e0"
+checksum = "cd7a0c48d503cf4e0a57a2453424eaef2fce4b4269f13e3579e52f0d0c9e5cc8"
 dependencies = [
  "regex",
  "streaming-iterator",


### PR DESCRIPTION
Highlighting a large, dense input can crash the whole process with SIGSEGV.

## Reproduction

A real hex package file that triggers it is `priv/static/assets/app.js` in [phoenix_analytics 0.3.2](https://hex.pm/packages/phoenix_analytics/0.3.2) (903,771 bytes, SHA-256 `020be8715a508700aa898b0fc441d54a2cf988c7455dc1ff1144624a9beb22d9`):

- Tarball: https://repo.hex.pm/tarballs/phoenix_analytics-0.3.2.tar (`priv/static/assets/app.js`)

```rust
let source = std::fs::read_to_string("app.js").unwrap();
let formatter = lumis::HtmlInlineBuilder::new()
    .language(lumis::languages::Language::JavaScript)
    .build()
    .unwrap();
let _ = lumis::highlight(&source, formatter); // SIGSEGV with tree-sitter 0.26.8
```

It reproduces in pure Rust through `lumis::highlight`, independent of the NIF, Rustler, and WASM layers. Highlighting it as plain text succeeds, and the raw parse of the same bytes is clean (no error, tree depth 73), so it is specific to the highlight query's capture iteration.

## Cause

The fault is in tree-sitter's query engine. `capture_list_pool_acquire` in `query.c` returned a 16-bit capture list id. Once a single highlight run needed more than 65,536 simultaneous in-progress capture lists, the id truncated and aliased a live list. A later release then corrupted the aliased list, leaving a `CaptureList` whose size passed the bounds guard but whose contents pointer was stale, so `ts_query_cursor__first_in_progress_capture` read out of bounds.

Upstream fixed this in [`tree-sitter/tree-sitter@0b9a7f8`](https://github.com/tree-sitter/tree-sitter/commit/0b9a7f87ee85ef25df892215c4c3beb48e701c63), "fix(query): widen capture list pool from uint16_t to uint32_t", released in tree-sitter 0.26.9. Per that commit, an earlier change (`1f6eac55`) had widened `QueryState.capture_list_id` to uint32_t and removed the 65,536 pool cap but left the pool function signatures at uint16_t, causing the silent truncation.

The trigger is dense, long unbroken lines of real minified code. It is not total file size (the same file wrapped to short lines does not crash), not nesting depth, and not a single construct (synthetic arrays, chains, and nested parens do not crash even much larger). The smallest crashing prefix of the sample file is about 144 KB.

## Fix

- Require `tree-sitter` and `tree-sitter-highlight` `>= 0.26.9` in the `lumis` and `lumis-cli` crates, and move the workspace lockfile and the Elixir NIF lockfile onto 0.26.11, so the fixed query engine is always used. The NIF lockfile was still pinned to the affected 0.26.8, which is what shipped in the crashing precompiled binary.
- Set a match limit equal to `u16::MAX` on the highlight query cursor in the vendored highlighter. This bounds the capture list pool below the historical 16-bit id space, so the pool cannot overflow even if an older tree-sitter is ever resolved, and it caps pool growth on pathological input.

## Verification

Verified in a Linux arm64 / OTP 28 container matching the reported environment:

- With the exact shipped versions (lumis 0.12.0, tree-sitter 0.26.8) the sample input segfaults through `lumis::highlight`; with tree-sitter 0.26.9, 0.26.10, and 0.26.11 it completes and produces correct output.
- With the match limit applied and tree-sitter pinned back to 0.26.8, the same input completes (exit 0); removing only the match limit line restores the segfault.
- `cargo test -p lumis` passes (66 tests), clippy and rustfmt are clean, and the NIF crate builds against tree-sitter 0.26.11.
