### PR TITLE
fix: keep Elixir NIF release artifacts local

### DIFF
--- a/packages/elixir/lumis/native/lumis_nif/.cargo/config.toml
+++ b/packages/elixir/lumis/native/lumis_nif/.cargo/config.toml
@@ -1,3 +1,8 @@
+# rustler-precompiled-action packages artifacts from this crate's target
+# directory, so keep it local even though the NIF is a root workspace member.
+[build]
+target-dir = "target"
+
 # Grammar crates generated with tree-sitter CLI < 0.26.4 ship an array.h whose
 # macros violate strict aliasing, which gcc -O2 miscompiles into heap
 # corruption (tree-sitter/tree-sitter@ed6e42c, tree-sitter/tree-sitter-haskell#144).


### PR DESCRIPTION
## Summary

- keep the Elixir NIF Cargo target directory local to the crate
- restore the artifact path expected by `rustler-precompiled-action`
- preserve the NIF's root-workspace membership and standalone packaged lockfile

## Root cause

After the NIF became a root workspace member, Cargo placed release artifacts under the repository-root `target` directory. The precompiled release action still packages artifacts from `packages/elixir/lumis/native/lumis_nif/target`, so all 15 native builds compiled successfully and then failed during the rename/package step with `No such file or directory`.

Failed release run: https://github.com/leandrocp/lumis/actions/runs/30037549894

## Validation

- `cargo build --locked --release --target aarch64-apple-darwin`
- verified `packages/elixir/lumis/native/lumis_nif/target/aarch64-apple-darwin/release/liblumis_nif.dylib`
- `mise run elixir-nif-lock-check`
- full tagless Elixir release matrix: all 15 build/package/artifact-upload jobs passed; release and Hex publication were intentionally skipped

Validation run: https://github.com/leandrocp/lumis/actions/runs/30038630181