### PR TITLE
fix(themes): stabilize generated updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -397,3 +397,6 @@ After regenerating, refresh CSS outputs:
 ```sh
 mise run css-gen
 ```
+
+Theme generation keeps the previous revision when an upstream commit produces
+identical theme data, so revision-only changes do not create update PRs.

--- a/crates/dev/src/main.rs
+++ b/crates/dev/src/main.rs
@@ -23,6 +23,10 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     GenCss,
+    FilterThemeUpdates {
+        #[arg(default_value = "")]
+        name: String,
+    },
     SyncThemes,
     SyncCss,
     ListThemes,
@@ -104,6 +108,7 @@ fn main() -> Result<()> {
 
     match cli.command {
         Commands::GenCss => gen_css(),
+        Commands::FilterThemeUpdates { name } => filter_theme_updates(&name),
         Commands::SyncThemes => sync_themes(),
         Commands::SyncCss => sync_css(),
         Commands::ListThemes => list_themes(),
@@ -570,6 +575,63 @@ fn gen_css() -> Result<()> {
         let css_path = css_dir.join(format!("{}.css", theme.name));
         fs::write(&css_path, css)?;
         println!("{}", css_path.display());
+    }
+
+    Ok(())
+}
+
+fn without_revision(mut theme: Value) -> Value {
+    if let Value::Object(fields) = &mut theme {
+        fields.remove("revision");
+    }
+    theme
+}
+
+fn is_revision_only_theme_update(previous: &Value, current: &Value) -> bool {
+    previous != current && without_revision(previous.clone()) == without_revision(current.clone())
+}
+
+fn filter_theme_updates(name: &str) -> Result<()> {
+    let mut theme_paths = if name.is_empty() {
+        glob::glob("themes/*.json")?.collect::<Result<Vec<_>, _>>()?
+    } else {
+        vec![PathBuf::from(format!("themes/{name}.json"))]
+    };
+    theme_paths.sort();
+
+    for path in theme_paths {
+        if !path.exists() {
+            continue;
+        }
+
+        let previous = Command::new("git")
+            .args(["show", &format!("HEAD:{}", path.display())])
+            .output()
+            .with_context(|| {
+                format!("failed to read the previous version of {}", path.display())
+            })?;
+
+        // A new theme has no version at HEAD and should always be kept.
+        if !previous.status.success() {
+            continue;
+        }
+
+        let previous_source = String::from_utf8(previous.stdout)
+            .with_context(|| format!("previous theme is not UTF-8: {}", path.display()))?;
+        let current_source = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read generated theme {}", path.display()))?;
+        let previous_theme: Value = serde_json::from_str(&previous_source)
+            .with_context(|| format!("invalid previous theme JSON: {}", path.display()))?;
+        let current_theme: Value = serde_json::from_str(&current_source)
+            .with_context(|| format!("invalid generated theme JSON: {}", path.display()))?;
+
+        if is_revision_only_theme_update(&previous_theme, &current_theme) {
+            fs::write(&path, previous_source)?;
+            println!(
+                "Ignored revision-only theme update: {}",
+                path.file_stem().unwrap().to_string_lossy()
+            );
+        }
     }
 
     Ok(())
@@ -2747,5 +2809,50 @@ mod tests {
             "\"nil\" @constant.builtin"
         );
         assert_eq!(apply_text_replacements(query, "nim"), query);
+    }
+
+    #[test]
+    fn revision_only_theme_updates_are_ignored() {
+        let previous = json!({
+            "name": "demo",
+            "appearance": "dark",
+            "revision": "old",
+            "highlights": {
+                "normal": { "fg": "#ffffff", "bg": "#000000" }
+            }
+        });
+        let current = json!({
+            "name": "demo",
+            "appearance": "dark",
+            "revision": "new",
+            "highlights": {
+                "normal": { "fg": "#ffffff", "bg": "#000000" }
+            }
+        });
+
+        assert!(is_revision_only_theme_update(&previous, &current));
+    }
+
+    #[test]
+    fn actual_theme_updates_are_kept() {
+        let previous = json!({
+            "name": "demo",
+            "appearance": "dark",
+            "revision": "old",
+            "highlights": {
+                "normal": { "fg": "#ffffff", "bg": "#000000" }
+            }
+        });
+        let current = json!({
+            "name": "demo",
+            "appearance": "dark",
+            "revision": "new",
+            "highlights": {
+                "normal": { "fg": "#eeeeee", "bg": "#000000" }
+            }
+        });
+
+        assert!(!is_revision_only_theme_update(&previous, &current));
+        assert!(!is_revision_only_theme_update(&previous, &previous));
     }
 }

--- a/mise.toml
+++ b/mise.toml
@@ -612,6 +612,7 @@ else
     [[ "$reply" =~ ^[Yy]$ ]] || { echo "Operation cancelled."; exit 0; }
     nvim --clean --headless -V3 -u themes/init.lua -l themes/extract_theme.lua ${usage_theme_name:-}
 fi
+cargo run --manifest-path crates/dev/Cargo.toml -- filter-theme-updates "${usage_theme_name:-}"
 cargo run --manifest-path crates/dev/Cargo.toml -- sync-themes
 pnpm --filter @lumis-sh/themes build:themes
 pnpm --filter @lumis-sh/themes build:assets

--- a/themes/themes.lua
+++ b/themes/themes.lua
@@ -6,16 +6,29 @@
 -- - config: Function to set up and activate the theme (required)
 -- - dependencies: Optional array of dependency URLs
 
-local function setup_material()
-	require("material").setup({
-		async_loading = false,
-		custom_highlights = function(colors)
-			-- material.nvim also defines a lowercase "exception" legacy group.
-			-- Highlight names are case-insensitive, so its self-link can clear
-			-- Exception depending on Lua table iteration order.
-			return { Exception = { fg = colors.main.red } }
-		end,
-	})
+local function load_material(colorscheme)
+	require("material").setup({ async_loading = false })
+
+	local original_set_hl = vim.api.nvim_set_hl
+	vim.api.nvim_set_hl = function(namespace_id, name, value)
+		local link = type(value) == "table" and value.link or nil
+
+		-- material.nvim defines a lowercase "exception" legacy alias.
+		-- Highlight names are case-insensitive, so applying that self-link
+		-- clears the concrete Exception style depending on iteration order.
+		if type(link) == "string" and string.lower(name) == string.lower(link) then
+			return
+		end
+
+		return original_set_hl(namespace_id, name, value)
+	end
+
+	local success, err = pcall(vim.cmd.colorscheme, colorscheme)
+	vim.api.nvim_set_hl = original_set_hl
+
+	if not success then
+		error(err)
+	end
 end
 
 return {
@@ -444,8 +457,7 @@ return {
 		config = function()
 			vim.o.background = "dark"
 			vim.g.material_style = "darker"
-			setup_material()
-			vim.cmd([[colorscheme material-darker]])
+			load_material("material-darker")
 		end,
 	},
 	{
@@ -454,8 +466,7 @@ return {
 		config = function()
 			vim.o.background = "light"
 			vim.g.material_style = "lighter"
-			setup_material()
-			vim.cmd([[colorscheme material-lighter]])
+			load_material("material-lighter")
 		end,
 	},
 	{
@@ -464,8 +475,7 @@ return {
 		config = function()
 			vim.o.background = "dark"
 			vim.g.material_style = "oceanic"
-			setup_material()
-			vim.cmd([[colorscheme material-oceanic]])
+			load_material("material-oceanic")
 		end,
 	},
 	{
@@ -474,8 +484,7 @@ return {
 		config = function()
 			vim.o.background = "dark"
 			vim.g.material_style = "palenight"
-			setup_material()
-			vim.cmd([[colorscheme material-palenight]])
+			load_material("material-palenight")
 		end,
 	},
 	{
@@ -484,8 +493,7 @@ return {
 		config = function()
 			vim.o.background = "dark"
 			vim.g.material_style = "deep ocean"
-			setup_material()
-			vim.cmd([[colorscheme material-deep-ocean]])
+			load_material("material-deep-ocean")
 		end,
 	},
 	{

--- a/themes/themes.lua
+++ b/themes/themes.lua
@@ -6,6 +6,18 @@
 -- - config: Function to set up and activate the theme (required)
 -- - dependencies: Optional array of dependency URLs
 
+local function setup_material()
+	require("material").setup({
+		async_loading = false,
+		custom_highlights = function(colors)
+			-- material.nvim also defines a lowercase "exception" legacy group.
+			-- Highlight names are case-insensitive, so its self-link can clear
+			-- Exception depending on Lua table iteration order.
+			return { Exception = { fg = colors.main.red } }
+		end,
+	})
+end
+
 return {
 	{
 		url = "https://github.com/folke/lazy.nvim",
@@ -432,7 +444,7 @@ return {
 		config = function()
 			vim.o.background = "dark"
 			vim.g.material_style = "darker"
-			require("material").setup({ async_loading = false })
+			setup_material()
 			vim.cmd([[colorscheme material-darker]])
 		end,
 	},
@@ -442,7 +454,7 @@ return {
 		config = function()
 			vim.o.background = "light"
 			vim.g.material_style = "lighter"
-			require("material").setup({ async_loading = false })
+			setup_material()
 			vim.cmd([[colorscheme material-lighter]])
 		end,
 	},
@@ -452,7 +464,7 @@ return {
 		config = function()
 			vim.o.background = "dark"
 			vim.g.material_style = "oceanic"
-			require("material").setup({ async_loading = false })
+			setup_material()
 			vim.cmd([[colorscheme material-oceanic]])
 		end,
 	},
@@ -462,7 +474,7 @@ return {
 		config = function()
 			vim.o.background = "dark"
 			vim.g.material_style = "palenight"
-			require("material").setup({ async_loading = false })
+			setup_material()
 			vim.cmd([[colorscheme material-palenight]])
 		end,
 	},
@@ -472,7 +484,7 @@ return {
 		config = function()
 			vim.o.background = "dark"
 			vim.g.material_style = "deep ocean"
-			require("material").setup({ async_loading = false })
+			setup_material()
 			vim.cmd([[colorscheme material-deep-ocean]])
 		end,
 	},


### PR DESCRIPTION
## Summary

- preserve the previous theme revision when regeneration produces identical theme data
- apply the filter before syncing generated Rust, JavaScript, Elixir, and CSS assets
- stabilize Material theme extraction by ignoring only its invalid case-insensitive self-link while the colorscheme loads; Lumis does not assign an exception color

## Root cause

The scheduled theme workflow treated upstream commit-only revision changes as merge-worthy, so it opened PR #1103 even though twelve themes had no effective data changes.

Material extraction had a separate nondeterministic failure. `material.nvim` defines a concrete `Exception` style and also a lowercase legacy `exception -> Exception` alias. Neovim highlight names are case-insensitive, so that alias is a self-link. Because the plugin applies highlight tables using unordered Lua iteration, the self-link could clear the concrete style before Lumis read `@keyword.exception`.

The fix temporarily ignores only case-insensitive self-links while loading a Material colorscheme and immediately restores Neovim's original API. All concrete highlight styles, including the final exception color, remain controlled by Material.

## Impact

Future theme runs retain real highlight, appearance, and new-theme changes, while revision-only updates no longer propagate into generated assets or create an automated PR. All five Material variants now load their upstream-defined exception style deterministically.

## Validation

- replayed the exact source theme changes from PR #1103: all 12 revision-only changes were filtered, leaving only the three reproduced Material flakes
- ran 50 clean Neovim processes across all five Material variants with zero missing `@keyword.exception` groups and confirmed the original `nvim_set_hl` function was restored after each load
- `cargo test --manifest-path crates/dev/Cargo.toml` (9 passed)
- `cargo fmt --manifest-path crates/dev/Cargo.toml --check`
- `stylua --check themes/themes.lua`
- `git diff --check`

The full `mise run fmt` reached the JavaScript dependency-install phase but could not complete in the restricted local environment because npm DNS was unavailable; the scoped Rust and Lua formatting checks passed.