### PR TITLE
ci: run benchmarks only on main

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,15 +1,15 @@
 name: Benchmarks
 
 concurrency:
-  group: >-
-    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
 
 on:
-  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   benchmark:


### PR DESCRIPTION
`.github/workflows/benchmarks.yml` is the only workflow with benchmark jobs, and it triggered on every pull request. It now triggers on push to `main`.

That covers all three jobs in the file:

- `benchmark` — the four-way matrix (Rust/syntect, JavaScript/Shiki, Elixir, CLI/bat) plus package sizes, 60-minute timeout each
- `report` — merges the partial artifacts into the step summary
- `comparison` — regenerates `website/public/comparison-data` via `showcase-publish` and fails if the committed assets are stale

The concurrency group dropped `github.event.pull_request.number`, which is always empty now that push is the only trigger.

Worth a look before merging: `comparison` is a staleness gate rather than a measurement, so this moves it from "a PR that forgets to run `showcase-publish` goes red" to "`main` goes red after the merge." If that check is worth keeping on pull requests, it needs to move to its own workflow.

`mise run lint-workflows` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Benchmark checks now run automatically when changes are pushed to the main branch.
  * Ongoing benchmark runs are canceled when newer runs for the same reference start.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->