### PR TITLE
ci: cut per-PR job count and stop rebuilding parsers

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
-      - uses: jdx/mise-action@v4.2.3
+      - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
         with:
           # Pinned: mise 2026.7.18 cannot install core:erlang/core:elixir on the
           # runner, and benchmarks/mise.lock was produced by this version.
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
-      - uses: jdx/mise-action@v4.2.3
+      - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
         with:
           # Pinned: mise 2026.7.18 cannot install core:erlang/core:elixir on the
           # runner, and benchmarks/mise.lock was produced by this version.
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24.18.0
       - name: Download partial benchmark reports

--- a/.github/workflows/cli-binary-release.yml
+++ b/.github/workflows/cli-binary-release.yml
@@ -21,7 +21,7 @@ jobs:
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-      - uses: softprops/action-gh-release@v3
+      - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           tag_name: ${{ inputs.tag || github.ref_name }}
           name: ${{ inputs.tag || github.ref_name }}
@@ -47,11 +47,11 @@ jobs:
             os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.tag || github.ref_name }}
 
-      - uses: taiki-e/upload-rust-binary-action@v1
+      - uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1
         id: upload
         with:
           bin: lumis
@@ -66,7 +66,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
-      - uses: actions/attest-build-provenance@v4
+      - uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
         with:
           subject-path: |
             ${{ steps.upload.outputs.tar }}

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -92,33 +92,33 @@ jobs:
             elixir: true
             build-parsers: true
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         if: matrix.rust
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         if: matrix.rust
 
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1
         if: matrix.elixir
         with:
           elixir-version: "1.19.x"
           otp-version: "28.x"
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         if: matrix.node
         with:
           version: 11.15.1
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         if: matrix.node
         with:
           node-version: "lts/*"
           cache: "pnpm"
           cache-dependency-path: pnpm-lock.yaml
 
-      - uses: jdx/mise-action@v4.2.3
+      - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
         with:
           install: false
 
@@ -147,7 +147,7 @@ jobs:
       # what the key no longer covers is rebuilt, not trusted.
       - name: Cache built parsers
         if: matrix.build-parsers
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: tmp/wasm/build
           key: wasm-parsers-${{ runner.os }}-conformance-${{ hashFiles('languages.toml', 'mise.toml') }}
@@ -157,7 +157,7 @@ jobs:
 
       - name: Cache the Tree-sitter WASI SDK
         if: matrix.build-parsers
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/tree-sitter
           key: ${{ runner.os }}-tree-sitter-cli-${{ hashFiles('mise.toml') }}
@@ -186,7 +186,7 @@ jobs:
         env:
           LUMIS_DATA_DIR: ${{ steps.parsers.outputs.path }}
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure() && matrix.browser
         with:
           name: javascript-browser-conformance-results

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -141,6 +141,29 @@ jobs:
         if: matrix.build-parsers
         run: mise install tree-sitter
 
+      # A built parser is a pure function of its pinned revision and the
+      # toolchain, so `build-wasm` records both next to the `.wasm` and reuses
+      # any file whose recording still matches. That makes a stale restore safe:
+      # what the key no longer covers is rebuilt, not trusted.
+      - name: Cache built parsers
+        if: matrix.build-parsers
+        uses: actions/cache@v6
+        with:
+          path: tmp/wasm/build
+          key: wasm-parsers-${{ runner.os }}-conformance-${{ hashFiles('languages.toml', 'mise.toml') }}
+          restore-keys: |
+            wasm-parsers-${{ runner.os }}-conformance-
+            wasm-parsers-${{ runner.os }}-
+
+      - name: Cache the Tree-sitter WASI SDK
+        if: matrix.build-parsers
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/tree-sitter
+          key: ${{ runner.os }}-tree-sitter-cli-${{ hashFiles('mise.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-tree-sitter-cli-
+
       - name: Build and stage the parsers the corpus uses
         if: matrix.build-parsers
         id: parsers

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -23,13 +23,13 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 11.15.1
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 'lts/*'
           cache: pnpm
@@ -51,7 +51,7 @@ jobs:
 
       - run: mkdir -p website/dist/docs && cp -R docs/build/. website/dist/docs/
 
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: website/dist
 
@@ -63,4 +63,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/elixir-nif-rust.yml
+++ b/.github/workflows/elixir-nif-rust.yml
@@ -32,9 +32,9 @@ jobs:
           (github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: prepare releases')) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Copy NIF crate outside the workspace
         run: |

--- a/.github/workflows/elixir-nif-rust.yml
+++ b/.github/workflows/elixir-nif-rust.yml
@@ -11,7 +11,6 @@ on:
     paths:
       - "packages/elixir/lumis/native/**"
       - "crates/**"
-      - "queries/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/elixir-nif-rust.yml"
@@ -19,7 +18,6 @@ on:
     paths:
       - "packages/elixir/lumis/native/**"
       - "crates/**"
-      - "queries/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/elixir-nif-rust.yml"
@@ -76,14 +74,3 @@ jobs:
       manifest-path: 'packages/elixir/lumis/native/lumis_nif/Cargo.toml'
       msrv: '1.91'
 
-  target-matrix:
-    name: Precompiled NIF target matrix
-    if: >-
-      ${{ github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'pull_request' && github.head_ref != 'knope/release') ||
-          (github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: prepare releases')) }}
-    uses: leandrocp/github-actions/.github/workflows/nif-release.yml@main
-    with:
-      project-name: lumis_nif
-      project-dir: packages/elixir/lumis/native/lumis_nif
-      working-directory: packages/elixir/lumis

--- a/.github/workflows/elixir-release.yml
+++ b/.github/workflows/elixir-release.yml
@@ -40,13 +40,13 @@ jobs:
         working-directory: packages/elixir/lumis
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.tag || github.ref }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1
         with:
           otp-version: "28"
           elixir-version: "1.19"

--- a/.github/workflows/gen-css.yml
+++ b/.github/workflows/gen-css.yml
@@ -25,12 +25,12 @@ jobs:
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
-      - uses: jdx/mise-action@v4.2.3
+      - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
         with:
           install: false
 
@@ -44,7 +44,7 @@ jobs:
         run: echo "y" | mise run css-gen
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.CI_TOKEN }}
           add-paths: |

--- a/.github/workflows/gen-themes.yml
+++ b/.github/workflows/gen-themes.yml
@@ -18,22 +18,22 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 11.15.1
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 'lts/*'
           cache: 'pnpm'
           cache-dependency-path: pnpm-lock.yaml
 
-      - uses: jdx/mise-action@v4.2.3
+      - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
         with:
           install: false
 
@@ -79,7 +79,7 @@ jobs:
           } > .github/gen-themes-pr-body.md
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.CI_TOKEN }}
           add-paths: |

--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -49,11 +49,11 @@ jobs:
             library: lumis_js_native.dll
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.tag || github.ref_name }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: ${{ matrix.target }}
 
@@ -70,7 +70,7 @@ jobs:
           cp "target/${{ matrix.target }}/release/${{ matrix.library }}" \
             "native-artifact/lumis-native.${{ matrix.package }}.node"
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: lumis-native-${{ matrix.package }}
           path: native-artifact/*.node
@@ -93,15 +93,15 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.tag || github.ref_name }}
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 11.15.1
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"
@@ -166,7 +166,7 @@ jobs:
 
       - name: Download native runtimes
         if: steps.pkg.outputs.filter == '@lumis-sh/lumis'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: lumis-native-*
           path: native-artifacts

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -58,12 +58,12 @@ jobs:
           (github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: prepare releases')) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: jdx/mise-action@v4.2.3
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 11.15.1
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 'lts/*'
           cache: 'pnpm'
@@ -91,12 +91,12 @@ jobs:
           (github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: prepare releases')) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 11.15.1
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 'lts/*'
           cache: 'pnpm'

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -147,4 +147,3 @@ jobs:
       - run: pnpm --filter @lumis-sh/react run test
         env:
           LUMIS_DATA_DIR: ${{ github.workspace }}/target/test-parsers
-      - run: pnpm --dir packages/javascript run build:wasm-bundles && git diff --exit-code -- packages/javascript/wasm-bundle-*

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Run actionlint
         uses: docker://rhysd/actionlint:1.7.12
         with:
@@ -44,16 +44,16 @@ jobs:
   lua:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: jdx/mise-action@v4.2.3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
       - run: mise run fmt-lua -- --check
 
   rust-outside-workspace:
     name: Rust crates outside the workspace
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: rustfmt
       - run: cargo fmt --manifest-path crates/dev/Cargo.toml --check

--- a/.github/workflows/queries.yml
+++ b/.github/workflows/queries.yml
@@ -59,13 +59,13 @@ jobs:
     name: Portability
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 11.15.1
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 'lts/*'
           cache: 'pnpm'
@@ -101,14 +101,14 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     steps:
-      - uses: actions/checkout@v7
-      - uses: jdx/mise-action@v4.2.3
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 11.15.1
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 'lts/*'
           cache: 'pnpm'
@@ -120,7 +120,7 @@ jobs:
         id: emsdk
         run: echo "version=$(mise exec -- printenv LUMIS_EMSDK_VERSION)" >> "$GITHUB_OUTPUT"
 
-      - uses: mymindstorm/setup-emsdk@v16
+      - uses: mymindstorm/setup-emsdk@4528d102f7230f0e7b276855c01ea1159be0e984 # v16
         with:
           version: ${{ steps.emsdk.outputs.version }}
           actions-cache-folder: emsdk-cache
@@ -129,7 +129,7 @@ jobs:
       # corpus, so a shared key would let whichever job finished first decide
       # what every other shard found in the cache.
       - name: Cache built parsers
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: tmp/wasm/build
           key: wasm-parsers-${{ runner.os }}-queries-${{ matrix.shard }}-${{ hashFiles('languages.toml', 'mise.toml') }}
@@ -138,7 +138,7 @@ jobs:
             wasm-parsers-${{ runner.os }}-
 
       - name: Cache the Tree-sitter WASI SDK
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/tree-sitter
           key: ${{ runner.os }}-tree-sitter-cli-${{ hashFiles('mise.toml') }}
@@ -229,11 +229,11 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 11.15.1
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 'lts/*'
           cache: 'pnpm'

--- a/.github/workflows/queries.yml
+++ b/.github/workflows/queries.yml
@@ -125,6 +125,26 @@ jobs:
           version: ${{ steps.emsdk.outputs.version }}
           actions-cache-folder: emsdk-cache
 
+      # Scoped per shard because each one builds a different slice of the
+      # corpus, so a shared key would let whichever job finished first decide
+      # what every other shard found in the cache.
+      - name: Cache built parsers
+        uses: actions/cache@v6
+        with:
+          path: tmp/wasm/build
+          key: wasm-parsers-${{ runner.os }}-queries-${{ matrix.shard }}-${{ hashFiles('languages.toml', 'mise.toml') }}
+          restore-keys: |
+            wasm-parsers-${{ runner.os }}-queries-${{ matrix.shard }}-
+            wasm-parsers-${{ runner.os }}-
+
+      - name: Cache the Tree-sitter WASI SDK
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/tree-sitter
+          key: ${{ runner.os }}-tree-sitter-cli-${{ hashFiles('mise.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-tree-sitter-cli-
+
       - name: Select this shard
         run: |
           set -euo pipefail

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -23,11 +23,11 @@ jobs:
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.tag || github.ref_name }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Determine crate to publish
         id: crate

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,10 +91,10 @@ jobs:
           (github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: prepare releases')) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: jdx/mise-action@v4.2.3
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: "crates/dev -> target"
           shared-key: language-catalog
@@ -114,11 +114,11 @@ jobs:
     env:
       MALLOC_CHECK_: "3"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
       - name: Package Lumis
         run: cargo package -p lumis --no-verify

--- a/.github/workflows/upgrade-langs.yml
+++ b/.github/workflows/upgrade-langs.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       languages: ${{ steps.set-matrix.outputs.languages }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Generate language matrix
         id: set-matrix
@@ -31,13 +31,13 @@ jobs:
   rust-cache:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: "crates/dev -> target"
           shared-key: update-langs-dev
@@ -59,25 +59,25 @@ jobs:
         language: ${{ fromJson(needs.generate-matrix.outputs.languages) }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: "crates/dev -> target"
           shared-key: update-langs-dev
           save-if: false
 
-      - uses: jdx/mise-action@v4.2.3
+      - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 11.15.1
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "lts/*"
           cache: "pnpm"
@@ -137,7 +137,7 @@ jobs:
       - name: Create Pull Request
         id: create-pr
         if: steps.check-changes.outputs.skip != 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.CI_TOKEN }}
           add-paths: |

--- a/.github/workflows/wasm-release.yml
+++ b/.github/workflows/wasm-release.yml
@@ -47,20 +47,20 @@ jobs:
       parsers: ${{ steps.needed.outputs.parsers }}
       skip: ${{ steps.needed.outputs.skip }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: jdx/mise-action@v4.2.3
+      - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: "crates/dev -> target"
           shared-key: wasm-release-detect
@@ -101,29 +101,29 @@ jobs:
         parser: ${{ fromJson(needs.detect.outputs.parsers) }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: jdx/mise-action@v4.2.3
+      - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
         with:
           install: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           shared-key: wasm-release
           add-job-id-key: false
       - name: Cache tree-sitter tool downloads
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/tree-sitter
           key: ${{ runner.os }}-tree-sitter-cli-${{ hashFiles('mise.toml') }}
           restore-keys: |
             ${{ runner.os }}-tree-sitter-cli-
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"
@@ -133,7 +133,7 @@ jobs:
         id: emsdk
         run: echo "version=$(mise exec -- printenv LUMIS_EMSDK_VERSION)" >> "$GITHUB_OUTPUT"
 
-      - uses: mymindstorm/setup-emsdk@v16
+      - uses: mymindstorm/setup-emsdk@4528d102f7230f0e7b276855c01ea1159be0e984 # v16
         with:
           version: ${{ steps.emsdk.outputs.version }}
           actions-cache-folder: emsdk-cache

--- a/crates/dev/src/main.rs
+++ b/crates/dev/src/main.rs
@@ -2269,17 +2269,26 @@ fn build_wasm(name: &str) -> Result<()> {
 
         let wasm_file = out_dir.join(format!("{wasm_name}.wasm"));
         let build_id_file = out_dir.join(format!("{wasm_name}.build-id"));
-        let build_id = wasm_build_id(git, rev, info.location.as_deref(), &toolchain);
+        let build_id = wasm_build_id(
+            git,
+            rev,
+            info.location.as_deref(),
+            info.generate.unwrap_or(false),
+            &toolchain,
+        );
 
-        if !rebuild
-            && wasm_file.exists()
-            && fs::read_to_string(&build_id_file).is_ok_and(|cached| cached == build_id)
-        {
+        if !rebuild && cached_parser_is_current(&wasm_file, &build_id_file, &build_id) {
             println!("-> Reusing {wasm_name} built from {rev}");
             continue;
         }
 
+        // A restored `.wasm` that this revision no longer describes has to go
+        // before the rebuild, not after it. `stage-wasm` and `test:queries`
+        // both take whatever file is present, so leaving the old one behind
+        // would let a parser that failed to build be staged, or have its
+        // queries checked against the grammar it replaced.
         let _ = fs::remove_file(&build_id_file);
+        let _ = fs::remove_file(&wasm_file);
 
         let clone_dir = format!("{tmp}/tree-sitter-{parser_name}");
         println!("-> Building WASM for {parser_name} ...");
@@ -2366,8 +2375,24 @@ fn wasm_toolchain_id() -> String {
     format!("{tree_sitter}\n{emsdk}")
 }
 
-fn wasm_build_id(git: &str, rev: &str, location: Option<&str>, toolchain: &str) -> String {
-    format!("{git}\n{rev}\n{}\n{toolchain}\n", location.unwrap_or(""))
+fn wasm_build_id(
+    git: &str,
+    rev: &str,
+    location: Option<&str>,
+    generate: bool,
+    toolchain: &str,
+) -> String {
+    format!(
+        "{git}\n{rev}\n{}\n{generate}\n{toolchain}\n",
+        location.unwrap_or("")
+    )
+}
+
+/// A recorded build id says the inputs still match; the magic number says the
+/// bytes survived being cached. Neither alone is enough to skip a build.
+fn cached_parser_is_current(wasm_file: &Path, build_id_file: &Path, build_id: &str) -> bool {
+    fs::read(wasm_file).is_ok_and(|bytes| bytes.starts_with(b"\0asm"))
+        && fs::read_to_string(build_id_file).is_ok_and(|cached| cached == build_id)
 }
 
 fn build_repo_wasm(repo_dir: &str, wasm_file: &Path, build_log: &Path) -> Result<()> {
@@ -3210,21 +3235,28 @@ mod tests {
 
     #[test]
     fn every_build_input_changes_the_build_id() {
-        let baseline = wasm_build_id("git://g", "rev1", Some("sub"), "ts\nem");
+        let baseline = wasm_build_id("git://g", "rev1", Some("sub"), false, "ts\nem");
 
         for (label, other) in [
             (
                 "git",
-                wasm_build_id("git://other", "rev1", Some("sub"), "ts\nem"),
+                wasm_build_id("git://other", "rev1", Some("sub"), false, "ts\nem"),
             ),
             (
                 "rev",
-                wasm_build_id("git://g", "rev2", Some("sub"), "ts\nem"),
+                wasm_build_id("git://g", "rev2", Some("sub"), false, "ts\nem"),
             ),
-            ("location", wasm_build_id("git://g", "rev1", None, "ts\nem")),
+            (
+                "location",
+                wasm_build_id("git://g", "rev1", None, false, "ts\nem"),
+            ),
+            (
+                "generate",
+                wasm_build_id("git://g", "rev1", Some("sub"), true, "ts\nem"),
+            ),
             (
                 "toolchain",
-                wasm_build_id("git://g", "rev1", Some("sub"), "ts\nem2"),
+                wasm_build_id("git://g", "rev1", Some("sub"), false, "ts\nem2"),
             ),
         ] {
             assert_ne!(baseline, other, "{label} must invalidate a cached parser");
@@ -3232,9 +3264,52 @@ mod tests {
 
         assert_eq!(
             baseline,
-            wasm_build_id("git://g", "rev1", Some("sub"), "ts\nem"),
+            wasm_build_id("git://g", "rev1", Some("sub"), false, "ts\nem"),
             "the same inputs must reuse a cached parser"
         );
+    }
+
+    #[test]
+    fn a_parser_is_reused_only_when_it_is_intact_and_current() {
+        let dir = PathBuf::from(tmpdir().unwrap());
+        let wasm = dir.join("tree-sitter-x.wasm");
+        let id_file = dir.join("tree-sitter-x.build-id");
+        let seed = |bytes: &[u8], id: &str| {
+            fs::write(&wasm, bytes).unwrap();
+            fs::write(&id_file, id).unwrap();
+        };
+
+        seed(b"\0asm\x01\0\0\0", "id-1");
+        assert!(
+            cached_parser_is_current(&wasm, &id_file, "id-1"),
+            "an intact parser recorded against these inputs is reusable"
+        );
+        assert!(
+            !cached_parser_is_current(&wasm, &id_file, "id-2"),
+            "a different build id must not be reused"
+        );
+
+        seed(b"corrupt", "id-1");
+        assert!(
+            !cached_parser_is_current(&wasm, &id_file, "id-1"),
+            "bytes that are not a wasm module must not be reused"
+        );
+
+        seed(b"\0asm\x01\0\0\0", "id-1");
+        fs::remove_file(&id_file).unwrap();
+        assert!(
+            !cached_parser_is_current(&wasm, &id_file, "id-1"),
+            "a parser with no recorded build id must not be reused"
+        );
+
+        fs::write(&id_file, "id-1").unwrap();
+        fs::remove_file(&wasm).unwrap();
+        assert!(
+            !cached_parser_is_current(&wasm, &id_file, "id-1"),
+            "a recorded build id without a parser must not be reused"
+        );
+
+        fs::remove_dir_all(&dir).unwrap();
     }
 
     fn published(hash: &str) -> Value {

--- a/crates/dev/src/main.rs
+++ b/crates/dev/src/main.rs
@@ -2250,6 +2250,8 @@ fn build_wasm(name: &str) -> Result<()> {
     fs::create_dir_all(&out_dir)?;
     fs::create_dir_all(&log_dir)?;
     let mut built_wasm_names = HashSet::new();
+    let toolchain = wasm_toolchain_id();
+    let rebuild = std::env::var("LUMIS_WASM_REBUILD").ok().as_deref() == Some("1");
 
     for (parser_name, info) in &toml.parsers {
         let Some(ref git) = info.git else { continue };
@@ -2266,6 +2268,18 @@ fn build_wasm(name: &str) -> Result<()> {
         }
 
         let wasm_file = out_dir.join(format!("{wasm_name}.wasm"));
+        let build_id_file = out_dir.join(format!("{wasm_name}.build-id"));
+        let build_id = wasm_build_id(git, rev, info.location.as_deref(), &toolchain);
+
+        if !rebuild
+            && wasm_file.exists()
+            && fs::read_to_string(&build_id_file).is_ok_and(|cached| cached == build_id)
+        {
+            println!("-> Reusing {wasm_name} built from {rev}");
+            continue;
+        }
+
+        let _ = fs::remove_file(&build_id_file);
 
         let clone_dir = format!("{tmp}/tree-sitter-{parser_name}");
         println!("-> Building WASM for {parser_name} ...");
@@ -2328,7 +2342,10 @@ fn build_wasm(name: &str) -> Result<()> {
         println!("* building wasm in {repo_dir}");
         println!("* build log: {}", build_log.display());
         match build_repo_wasm(&repo_dir, &wasm_file, &build_log) {
-            Ok(()) => println!("{wasm_path}"),
+            Ok(()) => {
+                fs::write(&build_id_file, &build_id)?;
+                println!("{wasm_path}");
+            }
             Err(_) => println!("  ERROR: failed to build {parser_name}"),
         }
 
@@ -2337,6 +2354,20 @@ fn build_wasm(name: &str) -> Result<()> {
 
     let _ = run_cmd_ok(&format!("rm -rf {tmp}"));
     Ok(())
+}
+
+/// Identifies the toolchain a `.wasm` was produced by. Emscripten is included
+/// even though `tree-sitter build --wasm` compiles through its own WASI SDK,
+/// because naming an input that turns out not to matter only rebuilds early,
+/// while omitting one that does matter reuses a stale parser.
+fn wasm_toolchain_id() -> String {
+    let tree_sitter = run_cmd("tree-sitter --version").unwrap_or_default();
+    let emsdk = std::env::var("LUMIS_EMSDK_VERSION").unwrap_or_default();
+    format!("{tree_sitter}\n{emsdk}")
+}
+
+fn wasm_build_id(git: &str, rev: &str, location: Option<&str>, toolchain: &str) -> String {
+    format!("{git}\n{rev}\n{}\n{toolchain}\n", location.unwrap_or(""))
 }
 
 fn build_repo_wasm(repo_dir: &str, wasm_file: &Path, build_log: &Path) -> Result<()> {
@@ -3176,6 +3207,35 @@ fn wasm_package_suffix(wasm_name: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn every_build_input_changes_the_build_id() {
+        let baseline = wasm_build_id("git://g", "rev1", Some("sub"), "ts\nem");
+
+        for (label, other) in [
+            (
+                "git",
+                wasm_build_id("git://other", "rev1", Some("sub"), "ts\nem"),
+            ),
+            (
+                "rev",
+                wasm_build_id("git://g", "rev2", Some("sub"), "ts\nem"),
+            ),
+            ("location", wasm_build_id("git://g", "rev1", None, "ts\nem")),
+            (
+                "toolchain",
+                wasm_build_id("git://g", "rev1", Some("sub"), "ts\nem2"),
+            ),
+        ] {
+            assert_ne!(baseline, other, "{label} must invalidate a cached parser");
+        }
+
+        assert_eq!(
+            baseline,
+            wasm_build_id("git://g", "rev1", Some("sub"), "ts\nem"),
+            "the same inputs must reuse a cached parser"
+        );
+    }
 
     fn published(hash: &str) -> Value {
         serde_json::json!({


### PR DESCRIPTION
CI runs ~59 jobs per pull request push. Measured over the last 1000 runs, a representative commit spent **188 minutes running and 215 minutes queued** — the runner pool is saturated, so removing a job pays twice: its own time, plus the queue time it imposed on everything behind it. Query shards were waiting 11–14 minutes to *start*.

## Delete the precompiled NIF target matrix

`elixir-nif-rust.yml` called `nif-release.yml` — a release workflow — on every PR touching `crates/**`, `queries/**`, or `Cargo.lock`, cross-compiling for 15 targets.

It never released anything and never could: the workflow has no `tags:` trigger, so the inner publish job's `startsWith(github.ref, 'refs/tags/')` gate is unreachable. It reported `skipped` on every run I sampled. `elixir-release.yml` builds and publishes the same 15 targets on `hex-lumis/v*`.

Evidence it was not earning its cost:

| Failing job, 300 runs (2026-07-12 → 08-08) | count |
|---|---:|
| `Standalone packaged NIF lockfile` | 10 |
| `test / os …` | 36 |
| `lint / …` | 7 |
| **`Precompiled NIF target matrix / …`** | **0** |

`lumis_nif` has zero `cfg(target_*)` / `cfg(unix)` / `cfg(windows)` blocks, so there is no platform-conditional code for a PR to break. And `release: needs: build` means a broken target fails the release rather than publishing — worst case is a re-tag, not a bad artifact on Hex.

`queries/**` is also dropped from the trigger; a `.scm` edit cannot change build portability.

## Cache built parsers

A `.wasm` is a pure function of its pinned revision (`languages.toml`) and the toolchain (`tree-sitter = "0.26"`, `LUMIS_EMSDK_VERSION = "4.0.15"`). Nothing else.

`build-wasm` now writes a `.build-id` next to each `.wasm` recording those inputs, and reuses any parser whose recording still matches. That makes a stale restore **safe** rather than merely lucky, which is what makes `restore-keys` usable: a one-language bump rebuilds one parser instead of all 110.

The cost being removed is not compilation — `build_wasm` does a `git clone` plus `npm install` per grammar. Measured locally on `tree-sitter-comment`: **9.8s cold, 1.4s warm**, and the wasm compile itself was 1 second of that.

Two duplications this removes:
- Conformance built the same 17 parsers **three times per run**, uncached, in the `CLI` / `JS-native` / `Elixir` legs.
- `~/.cache/tree-sitter`, where `tree-sitter build --wasm` puts the WASI SDK it fetches, was cached in `wasm-release.yml` but not in `queries.yml` or `conformance.yml` — so it was re-downloaded on all 15 parser-building jobs.

Cache keys are scoped per shard, because each shard builds a different slice of the corpus and a shared key would let whichever job finished first decide what every other shard found.

## Drop a duplicated check

`build:wasm-bundles && git diff --exit-code` ran in both the `lint` and `test` jobs of `javascript.yml`. The script only reads `languages.toml` and `package.json` files, so it stays in the cheaper `lint` job.

## Verification

- `mise run lint-workflows` (actionlint) passes
- `cargo test --manifest-path crates/dev/Cargo.toml --no-default-features` — 17 passed
- Cache behaviour exercised end-to-end: cold build writes both files, second run prints `Reusing`, and changing the pinned rev rebuilds
- `every_build_input_changes_the_build_id` was proven to fail by dropping `rev` from the id, then reverted

## Not in this PR

- **Query shard selection by changed language** — the second-largest lever (~14 jobs). It changes *what gets tested*, so it deserves its own review.
- **Removing `just` from the reusable workflows.** `chore: just -> mise (#1000)` deleted the justfile, but `leandrocp/github-actions` still installs it in `rust-test` (×3), `rust-lint`, `elixir-test`, and `elixir-lint` — ~20 jobs per PR. Separate repo, separate PR.
- **Collapsing the 5 per-crate Rust test jobs** — needs a local measurement of `--workspace --all-features` first, since it unions 200+ `lang-*` features.
- **Merge queue / draft gating** — needs a repo settings change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved build and validation times by reusing compatible parser and WebAssembly build artifacts.

* **Reliability**
  * Builds now detect source or toolchain changes and refresh outdated artifacts automatically.
  * Added safeguards to reject missing, corrupted, or incompatible build outputs.
  * Streamlined validation workflows to reduce unnecessary checks.

* **Tests**
  * Added coverage verifying artifact reuse and cache invalidation when relevant inputs change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->