### PR TITLE
fix(ci): repair the two test failures that block every PR

### DIFF
--- a/.github/workflows/upgrade-langs.yml
+++ b/.github/workflows/upgrade-langs.yml
@@ -142,6 +142,8 @@ jobs:
           token: ${{ secrets.CI_TOKEN }}
           add-paths: |
             languages.toml
+            Cargo.lock
+            crates/dev/Cargo.lock
             crates/lumis/Cargo.toml
             crates/lumis-core/Cargo.toml
             crates/lumis/vendored_parsers

--- a/crates/lumis-cli/src/registry.rs
+++ b/crates/lumis-cli/src/registry.rs
@@ -103,9 +103,12 @@ impl Registry {
         use lumis_wasm_runtime::{sha256_hex, write_atomic, PackagedLanguage, ParserMetadata};
 
         let location = catalog::find(id).unwrap();
+        // A cached package whose version is not the one this build pins is stale,
+        // so `LanguageStore::package` would refetch it and the seeded one would
+        // never be seen.
         let package = LanguagePackage {
             package_name: location.package_name.into(),
-            version: "test".into(),
+            version: location.version.into(),
             definition_hash: "test".into(),
             parser: ParserMetadata {
                 name: format!("tree-sitter-{grammar_name}"),
@@ -176,8 +179,11 @@ mod tests {
     #[test]
     fn parser_cache_is_content_addressed_and_verified() {
         let (_dir, registry) = cached_rust_registry();
+        let version = catalog::find("rust").unwrap().version;
         let path = registry.parser_path("rust").unwrap();
-        assert!(path.to_string_lossy().contains("tree-sitter-rust-test-"));
+        assert!(path
+            .to_string_lossy()
+            .contains(&format!("tree-sitter-rust-{version}-")));
         std::fs::write(&path, b"corrupt").unwrap();
         assert!(!registry.is_cached("rust"));
         assert!(!path.exists());
@@ -186,8 +192,9 @@ mod tests {
     #[test]
     fn package_url_is_exact_after_resolution() {
         let (_dir, registry) = cached_rust_registry();
+        let version = catalog::find("rust").unwrap().version;
         let url = registry.parser_download_url("rust").unwrap();
-        assert!(url.contains("@lumis-sh/wasm-rust@test/"));
+        assert!(url.contains(&format!("@lumis-sh/wasm-rust@{version}/")));
         assert!(!url.contains("@latest"));
     }
 }

--- a/mise.toml
+++ b/mise.toml
@@ -597,6 +597,7 @@ set -euo pipefail
 mise run langs-fetch-vendored-parsers ${usage_name?}
 cargo run --manifest-path crates/dev/Cargo.toml --no-default-features -- cargo-update-dep ${usage_name?}
 cargo run --manifest-path crates/dev/Cargo.toml --no-default-features -- cargo-update-features
+mise run langs-sync-lockfiles
 mise run langs-gen-catalog
 mise run langs-fetch-queries ${usage_name?}
 mise run langs-preprocess-queries ${usage_name?}
@@ -702,6 +703,16 @@ set -euo pipefail
 cargo run --manifest-path crates/dev/Cargo.toml --no-default-features -- upgrade-parsers ${usage_name:-}
 cargo run --manifest-path crates/dev/Cargo.toml --no-default-features -- cargo-update-dep ${usage_name:-}
 cargo run --manifest-path crates/dev/Cargo.toml --no-default-features -- cargo-update-features
+mise run langs-sync-lockfiles
+'''
+
+[tasks.'langs-sync-lockfiles']
+description = "Re-resolve both lockfiles after a crate-backed parser version changes, so --locked builds still work"
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+cargo metadata --format-version 1 >/dev/null
+cargo metadata --manifest-path crates/dev/Cargo.toml --format-version 1 >/dev/null
 '''
 
 [tasks.'langs-upgrade-queries']

--- a/packages/javascript/lumis/test/native-runtime.test.ts
+++ b/packages/javascript/lumis/test/native-runtime.test.ts
@@ -277,11 +277,47 @@ describe("native runtime", () => {
   });
 
   it.runIf(binding)("leaves a document alone when an injected language is unavailable", () => {
-    const runtime = new binding!.NativeRuntime();
-    // `comment` is staged, `regex` is not, and markdown injects both.
-    const highlighted = runtime.highlightEvents("```regex\n[a-z]+\n```\n", "markdown", false);
+    const nativeDirectory = resolve(import.meta.dirname, "../native");
+    const addon = readdirSync(nativeDirectory).find(
+      (name) => name.startsWith("lumis-native.") && name.endsWith(".node"),
+    );
+    expect(addon).toBeDefined();
 
-    expect(highlighted.events.length).toBeGreaterThan(0);
+    // `comment` is staged and `regex` is not, but both are published, so a
+    // store that can reach the CDN resolves `regex` and reports nothing. Only
+    // an unreachable one makes "not staged" mean "unavailable"; the child
+    // process is what keeps the poisoned proxy out of every other test.
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--input-type=commonjs",
+        "--eval",
+        `
+          const binding = require(process.argv[1]);
+          const runtime = new binding.NativeRuntime();
+          const highlighted = runtime.highlightEvents(process.argv[2], "markdown", false);
+          process.stdout.write(
+            JSON.stringify({
+              events: highlighted.events.length,
+              unresolved: highlighted.unresolved,
+            }),
+          );
+        `,
+        resolve(nativeDirectory, addon!),
+        "```regex\n[a-z]+\n```\n",
+      ],
+      {
+        encoding: "utf8",
+        env: { ...process.env, ALL_PROXY: "http://127.0.0.1:1", NO_PROXY: "", no_proxy: "" },
+        timeout: 30_000,
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stderr).toBe(0);
+
+    const highlighted = JSON.parse(result.stdout) as { events: number; unresolved: string[] };
+    expect(highlighted.events).toBeGreaterThan(0);
     // Reported rather than swallowed, so a caller that resolves parsers itself
     // can tell the difference between "no injection" and "could not load it".
     expect(highlighted.unresolved).toContain("regex");


### PR DESCRIPTION
`test-lumis-cli` and the Node `test` job have been red on `main` since #1099, so every open PR inherits two failures it did not cause. Both tests assumed a package that #1099's catalog now pins to a published version.

## `registry::tests` (Rust, all platforms)

`cache_test_language` seeded its package as version `"test"`. `LanguageStore::package` treats a cached package whose version is not the catalog pin as stale, so it refetched from the CDN and the seeded package was never the one under test — `parser_path` and `parser_download_url` then reported the real `0.26.3` package instead of the seeded one.

Seeding the catalog's pinned version keeps the store on disk. Verified both tests pass with `ALL_PROXY=http://127.0.0.1:1`, so they no longer depend on the network at all.

## `leaves a document alone when an injected language is unavailable` (Node)

The test relied on `regex` being unstaged to make it unavailable, but `@lumis-sh/wasm-regex@0.26.1` has been published since 2026-06-09, so the addon downloaded it and `unresolved` came back empty.

It now runs in a child process with the CDN unreachable, which is what makes "not staged" mean "unavailable" regardless of what is published. The child is what keeps the poisoned proxy out of every other test in the file.

Confirmed the assertion is load-bearing rather than vacuous — same document, same addon, only the reachability differs:

| | `events` | `unresolved` |
| --- | --- | --- |
| CDN reachable | 272 | `[]` |
| CDN unreachable | 152 | `["regex"]` |

## Lockfiles on parser bumps

`upgrade-langs` never staged `Cargo.lock` or `crates/dev/Cargo.lock`, so a parser bump that moves a crates.io version shipped a tree that fails `--locked`. #1121 hit exactly that: `check-language-catalog` died in 20s because `crates/lumis/Cargo.toml` wanted `tree-sitter-fsharp` 0.3.11 while both lockfiles still pinned 0.3.10.

`langs-sync-lockfiles` re-resolves both, called from `langs-upgrade-parsers` and `langs-update` so local runs and CI stay in step, and the workflow now commits them.

## Verification

- `cargo test -p lumis-cli --bins registry::tests` — 3 passed, also with the network blocked
- `vitest run test/native-runtime.test.ts` — 14 passed
- `actionlint`, `oxfmt --check`, `oxlint --deny-warnings`, `cargo fmt --check`, `cargo clippy -p lumis-cli -- -D warnings`