### PR TITLE
fix(dev): exit non-zero when a parser fails to build

### DIFF
--- a/crates/dev/src/main.rs
+++ b/crates/dev/src/main.rs
@@ -2256,6 +2256,7 @@ fn build_wasm(name: &str) -> Result<()> {
     fs::create_dir_all(&out_dir)?;
     fs::create_dir_all(&log_dir)?;
     let mut built_wasm_names = HashSet::new();
+    let mut failed = Vec::new();
     let toolchain = wasm_toolchain_id();
     let rebuild = std::env::var("LUMIS_WASM_REBUILD").ok().as_deref() == Some("1");
 
@@ -2361,13 +2362,24 @@ fn build_wasm(name: &str) -> Result<()> {
                 fs::write(&build_id_file, &build_id)?;
                 println!("{wasm_path}");
             }
-            Err(_) => println!("  ERROR: failed to build {parser_name}"),
+            Err(_) => {
+                println!("  ERROR: failed to build {parser_name}");
+                failed.push(parser_name.clone());
+            }
         }
 
         let _ = run_cmd_ok(&format!("rm -rf {clone_dir}"));
     }
 
     let _ = run_cmd_ok(&format!("rm -rf {tmp}"));
+
+    // Reported once at the end rather than by returning early, so building the
+    // whole corpus still attempts every parser and names all the failures
+    // instead of stopping at the first.
+    if !failed.is_empty() {
+        bail!("failed to build: {}", failed.join(", "));
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
`build-wasm` reports a failed build and then exits 0:

```
$ mise run wasm-build json     # with a compiler that exits 1
  ERROR: failed to build json
$ echo $?
0
```

`build_wasm` prints the error inside the loop and returns `Ok(())` at the end, so the failure never reaches the exit code.

## Why it has not bitten yet

`wasm-publish-prepare` runs `wasm-build` and then `stage-wasm`, and `stage-wasm` bails when the `.wasm` is missing. That backstop is the only thing standing between a failed build and a publish. Anything that runs `wasm-build` on its own, or reads its exit code, is told the parser built — `conformance.yml` and `queries.yml` both call it directly in a loop.

## Change

Collect the failures and return an error once the loop finishes.

Reporting at the end rather than returning early is deliberate: `mise run wasm-build` with no argument builds the whole corpus, and stopping at the first failure would hide the rest. That is presumably why the error was swallowed to begin with — the fix keeps the "attempt everything" behaviour and makes the exit code truthful, naming every parser that failed.

## Verification

With a stub compiler that exits 1, driven through the real `build-wasm` path:

| case | before | after |
| --- | --- | --- |
| build fails | exit 0 | exit 1 |
| build succeeds | exit 0 | exit 0 |
| cached parser reused | exit 0 | exit 0 |

`tree-sitter-json` still builds to `6c80de1a…`, unchanged, and the cache-reuse path still reports `Reusing tree-sitter-json built from ee35a6eb…`. 20 tests pass, clippy clean.

Follows #1136, which fixed the neighbouring half of this: `build_repo_wasm` returning `Ok(())` because the build ran through `sh -c ... | tee` and a pipeline exits with `tee`'s status. That made the compiler's status reach the caller; this makes the caller's status reach the shell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Parser builds now continue for all selected parsers, even when one fails.
  * Build results report all parser failures together after cleanup, making troubleshooting clearer.
  * Successful parser builds retain their existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->