### PR TITLE
perf(dev): query the npm registry directly instead of shelling out to npm view

### DIFF
--- a/.github/workflows/wasm-release.yml
+++ b/.github/workflows/wasm-release.yml
@@ -51,11 +51,6 @@ jobs:
 
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: "lts/*"
-          registry-url: "https://registry.npmjs.org"
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 

--- a/crates/dev/src/main.rs
+++ b/crates/dev/src/main.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use xz2::write::XzEncoder;
 
 #[derive(Parser)]
@@ -2149,7 +2149,7 @@ fn resolve_published_versions(
     parsers: &BTreeMap<String, ParserInfo>,
     parser_order: &[String],
 ) -> Result<BTreeMap<String, String>> {
-    let mut versions: BTreeMap<String, String> = BTreeMap::new();
+    let mut packages: Vec<String> = Vec::new();
     for id in parser_order {
         let info = parsers
             .get(id)
@@ -2157,26 +2157,24 @@ fn resolve_published_versions(
         let default_wasm_name = format!("tree-sitter-{id}");
         let wasm_name = info.wasm_name.as_deref().unwrap_or(&default_wasm_name);
         let package_name = format!("@lumis-sh/wasm-{}", wasm_package_suffix(wasm_name));
-        if versions.contains_key(&package_name) {
-            continue;
+        if !packages.contains(&package_name) {
+            packages.push(package_name);
         }
+    }
 
-        let output = Command::new("npm")
-            .args(["view", &package_name, "version"])
-            .output()
-            .with_context(|| format!("failed to run npm view for {package_name}"))?;
-        if !output.status.success() {
-            bail!(
-                "{package_name} is not published; the catalog cannot pin a version for it:\n{}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            );
-        }
-        let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if version.is_empty() {
-            bail!("npm view returned no version for {package_name}");
-        }
+    let mut versions: BTreeMap<String, String> = BTreeMap::new();
+    for (package_name, packument) in packages.iter().zip(fetch_packuments(&packages)) {
+        let version = packument?
+            .as_ref()
+            .and_then(|packument| packument.get("dist-tags"))
+            .and_then(|tags| tags.get("latest"))
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+            .with_context(|| {
+                format!("{package_name} is not published; the catalog cannot pin a version for it")
+            })?;
         eprintln!("  {package_name} {version}");
-        versions.insert(package_name, version);
+        versions.insert(package_name.clone(), version);
     }
     Ok(versions)
 }
@@ -3093,6 +3091,8 @@ const PACKAGE_FORMAT_VERSION: u32 = 3;
 
 const REGISTRY_CONCURRENCY: usize = 16;
 
+const REGISTRY_ATTEMPTS: u32 = 3;
+
 /// The `major.minor` series published packages are versioned within.
 ///
 /// Read from the `mise.toml` pin rather than the installed CLI, so this answers
@@ -3129,20 +3129,57 @@ fn supported_tree_sitter_series() -> Result<String> {
 /// answers what `npm view` needs one call per version to answer.
 fn fetch_packument(agent: &ureq::Agent, pkg: &str) -> Result<Option<Value>> {
     let url = format!("https://registry.npmjs.org/{pkg}");
-    let mut response = match agent.get(&url).call() {
-        Ok(response) => response,
-        Err(ureq::Error::StatusCode(404)) => return Ok(None),
-        Err(err) => {
-            return Err(err).with_context(|| format!("failed to query {pkg} on the npm registry"))
+    let mut last_error = None;
+
+    for attempt in 0..REGISTRY_ATTEMPTS {
+        if attempt > 0 {
+            thread::sleep(Duration::from_millis(250 * u64::from(attempt)));
         }
-    };
-    let body = response
-        .body_mut()
-        .read_to_string()
-        .with_context(|| format!("failed to read the npm registry response for {pkg}"))?;
-    let packument =
-        serde_json::from_str(&body).with_context(|| format!("invalid packument for {pkg}"))?;
-    Ok(Some(packument))
+        match agent.get(&url).call() {
+            Ok(mut response) => {
+                let body = response.body_mut().read_to_string().with_context(|| {
+                    format!("failed to read the npm registry response for {pkg}")
+                })?;
+                let packument = serde_json::from_str(&body)
+                    .with_context(|| format!("invalid packument for {pkg}"))?;
+                return Ok(Some(packument));
+            }
+            Err(ureq::Error::StatusCode(404)) => return Ok(None),
+            Err(err) => last_error = Some(err),
+        }
+    }
+
+    Err(last_error.expect("a failed attempt records its error"))
+        .with_context(|| format!("failed to query {pkg} on the npm registry"))
+}
+
+/// Each request is almost entirely round trip, so the whole catalog is worth
+/// fetching at once. Results come back in the order the packages were given.
+fn fetch_packuments(packages: &[String]) -> Vec<Result<Option<Value>>> {
+    let agent = ureq::Agent::new_with_defaults();
+    let next = AtomicUsize::new(0);
+    let mut fetched: Vec<(usize, Result<Option<Value>>)> = thread::scope(|scope| {
+        let workers: Vec<_> = (0..REGISTRY_CONCURRENCY.min(packages.len()))
+            .map(|_| {
+                scope.spawn(|| {
+                    let mut done = Vec::new();
+                    loop {
+                        let index = next.fetch_add(1, Ordering::Relaxed);
+                        let Some(pkg) = packages.get(index) else {
+                            return done;
+                        };
+                        done.push((index, fetch_packument(&agent, pkg)));
+                    }
+                })
+            })
+            .collect();
+        workers
+            .into_iter()
+            .flat_map(|worker| worker.join().expect("npm registry worker panicked"))
+            .collect()
+    });
+    fetched.sort_by_key(|(index, _)| *index);
+    fetched.into_iter().map(|(_, result)| result).collect()
 }
 
 /// Whether some published version in the current series already carries this
@@ -3220,39 +3257,13 @@ fn wasm_needed(filter: &str, force: &str) -> Result<()> {
         checks.push((wasm_name, pkg, expected));
     }
 
-    let agent = ureq::Agent::new_with_defaults();
-    let next = AtomicUsize::new(0);
-    let mut results: Vec<(usize, Result<bool>)> = thread::scope(|scope| {
-        let workers: Vec<_> = (0..REGISTRY_CONCURRENCY.min(checks.len()))
-            .map(|_| {
-                scope.spawn(|| {
-                    let mut done = Vec::new();
-                    loop {
-                        let index = next.fetch_add(1, Ordering::Relaxed);
-                        let Some((_, pkg, expected)) = checks.get(index) else {
-                            return done;
-                        };
-                        let published = fetch_packument(&agent, pkg).map(|packument| {
-                            packument.is_some_and(|packument| {
-                                published_for_definition(&packument, expected, &series)
-                            })
-                        });
-                        done.push((index, published));
-                    }
-                })
-            })
-            .collect();
-        workers
-            .into_iter()
-            .flat_map(|worker| worker.join().expect("npm registry worker panicked"))
-            .collect()
-    });
-    results.sort_by_key(|(index, _)| *index);
+    let packages: Vec<String> = checks.iter().map(|(_, pkg, _)| pkg.clone()).collect();
 
     let mut needed = Vec::new();
-    for (index, published) in results {
-        let (wasm_name, pkg, expected) = &checks[index];
-        if !published? {
+    for ((wasm_name, pkg, expected), packument) in checks.iter().zip(fetch_packuments(&packages)) {
+        let published = packument?
+            .is_some_and(|packument| published_for_definition(&packument, expected, &series));
+        if !published {
             eprintln!("Need to publish {pkg} for {expected}");
             needed.push(wasm_name.clone());
         }

--- a/crates/dev/src/main.rs
+++ b/crates/dev/src/main.rs
@@ -3093,6 +3093,8 @@ const REGISTRY_CONCURRENCY: usize = 16;
 
 const REGISTRY_ATTEMPTS: u32 = 3;
 
+const REGISTRY_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// The `major.minor` series published packages are versioned within.
 ///
 /// Read from the `mise.toml` pin rather than the installed CLI, so this answers
@@ -3127,6 +3129,11 @@ fn supported_tree_sitter_series() -> Result<String> {
 
 /// The full packument carries every version's `package.json`, so one request
 /// answers what `npm view` needs one call per version to answer.
+///
+/// Unlike `npm view`, this reads npmjs.org rather than whatever registry npm is
+/// configured for. Both release workflows pin that host explicitly and every
+/// `@lumis-sh/wasm-*` package is public, so a mirror or private registry is out
+/// of scope here.
 fn fetch_packument(agent: &ureq::Agent, pkg: &str) -> Result<Option<Value>> {
     let url = format!("https://registry.npmjs.org/{pkg}");
     let mut last_error = None;
@@ -3135,11 +3142,14 @@ fn fetch_packument(agent: &ureq::Agent, pkg: &str) -> Result<Option<Value>> {
         if attempt > 0 {
             thread::sleep(Duration::from_millis(250 * u64::from(attempt)));
         }
-        match agent.get(&url).call() {
-            Ok(mut response) => {
-                let body = response.body_mut().read_to_string().with_context(|| {
-                    format!("failed to read the npm registry response for {pkg}")
-                })?;
+        // `call` returns once the headers arrive, so a reset or truncated body
+        // surfaces from the read and is just as transient as a failed connect.
+        let read = agent
+            .get(&url)
+            .call()
+            .and_then(|mut response| response.body_mut().read_to_string());
+        match read {
+            Ok(body) => {
                 let packument = serde_json::from_str(&body)
                     .with_context(|| format!("invalid packument for {pkg}"))?;
                 return Ok(Some(packument));
@@ -3156,7 +3166,10 @@ fn fetch_packument(agent: &ureq::Agent, pkg: &str) -> Result<Option<Value>> {
 /// Each request is almost entirely round trip, so the whole catalog is worth
 /// fetching at once. Results come back in the order the packages were given.
 fn fetch_packuments(packages: &[String]) -> Vec<Result<Option<Value>>> {
-    let agent = ureq::Agent::new_with_defaults();
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_global(Some(REGISTRY_TIMEOUT))
+        .build()
+        .into();
     let next = AtomicUsize::new(0);
     let mut fetched: Vec<(usize, Result<Option<Value>>)> = thread::scope(|scope| {
         let workers: Vec<_> = (0..REGISTRY_CONCURRENCY.min(packages.len()))
@@ -3280,6 +3293,89 @@ fn wasm_package_suffix(wasm_name: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const HASH: &str = "a4ee9c153c66f995d081895c3e57a0a4eed81ebb91f2320a0810bbf51c3598dc";
+
+    fn packument(versions: Value) -> Value {
+        json!({ "versions": versions })
+    }
+
+    fn marker(hash: &str, series: &str, format: u32) -> Value {
+        json!({
+            "lumis": {
+                "definitionHash": hash,
+                "treeSitter": series,
+                "formatVersion": format,
+            }
+        })
+    }
+
+    #[test]
+    fn a_published_version_carrying_the_definition_needs_no_republish() {
+        let packument = packument(json!({
+            "0.25.0": marker(HASH, "0.25", PACKAGE_FORMAT_VERSION),
+            "0.26.0": json!({ "lumis": { "rev": "18b0515", "treeSitter": "0.26" } }),
+            "0.26.1": marker(HASH, "0.26", PACKAGE_FORMAT_VERSION),
+        }));
+
+        assert!(published_for_definition(&packument, HASH, "0.26"));
+    }
+
+    #[test]
+    fn a_definition_published_only_outside_the_series_still_needs_publishing() {
+        let packument = packument(json!({
+            "0.25.0": marker(HASH, "0.25", PACKAGE_FORMAT_VERSION),
+        }));
+
+        assert!(!published_for_definition(&packument, HASH, "0.26"));
+    }
+
+    #[test]
+    fn a_neighbouring_series_is_not_a_prefix_match() {
+        let packument = packument(json!({
+            "0.260.0": marker(HASH, "0.26", PACKAGE_FORMAT_VERSION),
+        }));
+
+        assert!(!published_for_definition(&packument, HASH, "0.26"));
+    }
+
+    #[test]
+    fn every_stale_marker_needs_publishing() {
+        for (label, manifest) in [
+            ("no lumis key", json!({ "name": "@lumis-sh/wasm-rust" })),
+            (
+                "pre-v3 marker",
+                json!({ "lumis": { "rev": "18b0515", "treeSitter": "0.26" } }),
+            ),
+            (
+                "older format",
+                marker(HASH, "0.26", PACKAGE_FORMAT_VERSION - 1),
+            ),
+            (
+                "different definition",
+                marker("0000000000000000", "0.26", PACKAGE_FORMAT_VERSION),
+            ),
+            (
+                "series disagrees with the version",
+                marker(HASH, "0.25", PACKAGE_FORMAT_VERSION),
+            ),
+        ] {
+            let packument = packument(json!({ "0.26.0": manifest }));
+            assert!(
+                !published_for_definition(&packument, HASH, "0.26"),
+                "{label} must not count as published"
+            );
+        }
+    }
+
+    #[test]
+    fn a_packument_without_versions_needs_publishing() {
+        assert!(!published_for_definition(
+            &json!({ "dist-tags": { "latest": "0.26.1" } }),
+            HASH,
+            "0.26"
+        ));
+    }
 
     #[test]
     fn every_build_input_changes_the_build_id() {

--- a/crates/dev/src/main.rs
+++ b/crates/dev/src/main.rs
@@ -12,6 +12,8 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
 use std::time::Instant;
 use xz2::write::XzEncoder;
 
@@ -3089,6 +3091,8 @@ fn wasm_meta(name: &str) -> Result<()> {
 
 const PACKAGE_FORMAT_VERSION: u32 = 3;
 
+const REGISTRY_CONCURRENCY: usize = 16;
+
 /// The `major.minor` series published packages are versioned within.
 ///
 /// Read from the `mise.toml` pin rather than the installed CLI, so this answers
@@ -3121,28 +3125,39 @@ fn supported_tree_sitter_series() -> Result<String> {
     Ok(format!("{}.{}", parts[0], parts[1]))
 }
 
+/// The full packument carries every version's `package.json`, so one request
+/// answers what `npm view` needs one call per version to answer.
+fn fetch_packument(agent: &ureq::Agent, pkg: &str) -> Result<Option<Value>> {
+    let url = format!("https://registry.npmjs.org/{pkg}");
+    let mut response = match agent.get(&url).call() {
+        Ok(response) => response,
+        Err(ureq::Error::StatusCode(404)) => return Ok(None),
+        Err(err) => {
+            return Err(err).with_context(|| format!("failed to query {pkg} on the npm registry"))
+        }
+    };
+    let body = response
+        .body_mut()
+        .read_to_string()
+        .with_context(|| format!("failed to read the npm registry response for {pkg}"))?;
+    let packument =
+        serde_json::from_str(&body).with_context(|| format!("invalid packument for {pkg}"))?;
+    Ok(Some(packument))
+}
+
 /// Whether some published version in the current series already carries this
 /// exact language definition.
-fn published_for_definition(pkg: &str, versions: &[String], expected: &str, series: &str) -> bool {
+fn published_for_definition(packument: &Value, expected: &str, series: &str) -> bool {
+    let Some(versions) = packument.get("versions").and_then(Value::as_object) else {
+        return false;
+    };
     let prefix = format!("{series}.");
-    for version in versions.iter().filter(|v| v.starts_with(&prefix)) {
-        let Ok(output) = Command::new("npm")
-            .args(["view", &format!("{pkg}@{version}"), "lumis", "--json"])
-            .output()
-        else {
-            continue;
-        };
-        if !output.status.success() {
-            continue;
-        }
-        let Ok(meta) = serde_json::from_slice::<Value>(&output.stdout) else {
-            continue;
-        };
-        if definition_matches(&meta, expected, series) {
-            return true;
-        }
-    }
-    false
+    versions.iter().any(|(version, manifest)| {
+        version.starts_with(&prefix)
+            && manifest
+                .get("lumis")
+                .is_some_and(|meta| definition_matches(meta, expected, series))
+    })
 }
 
 /// Packages published before the v3 format carry no `definitionHash`, so they
@@ -3179,7 +3194,7 @@ fn wasm_needed(filter: &str, force: &str) -> Result<()> {
         }
     }
 
-    let mut needed = Vec::new();
+    let mut candidates = Vec::new();
     let mut seen = HashSet::new();
     for (id, info) in &toml.parsers {
         let default_name = format!("tree-sitter-{id}");
@@ -3187,34 +3202,59 @@ fn wasm_needed(filter: &str, force: &str) -> Result<()> {
         if !wanted.is_empty() && !wanted.contains(id.as_str()) && !wanted.contains(wasm_name) {
             continue;
         }
-        if !seen.insert(wasm_name.to_string()) {
-            continue;
+        if seen.insert(wasm_name.to_string()) {
+            candidates.push(wasm_name.to_string());
         }
-        if force {
-            needed.push(wasm_name.to_string());
-            continue;
-        }
+    }
 
-        let pkg = format!("@lumis-sh/wasm-{}", wasm_package_suffix(wasm_name));
-        let output = Command::new("npm")
-            .args(["view", &pkg, "versions", "--json"])
-            .output();
-        let versions = match &output {
-            Ok(output) if output.status.success() => {
-                parse_npm_versions_json(&String::from_utf8_lossy(&output.stdout))
-                    .unwrap_or_default()
-            }
-            _ => {
-                needed.push(wasm_name.to_string());
-                continue;
-            }
-        };
+    if force {
+        println!("{}", candidates.join(" "));
+        return Ok(());
+    }
 
-        let languages = packaged_languages(&toml, wasm_name)?;
-        let expected = language_definition_hash(&toml, wasm_name, &languages)?;
-        if !published_for_definition(&pkg, &versions, &expected, &series) {
+    let mut checks = Vec::with_capacity(candidates.len());
+    for wasm_name in candidates {
+        let languages = packaged_languages(&toml, &wasm_name)?;
+        let expected = language_definition_hash(&toml, &wasm_name, &languages)?;
+        let pkg = format!("@lumis-sh/wasm-{}", wasm_package_suffix(&wasm_name));
+        checks.push((wasm_name, pkg, expected));
+    }
+
+    let agent = ureq::Agent::new_with_defaults();
+    let next = AtomicUsize::new(0);
+    let mut results: Vec<(usize, Result<bool>)> = thread::scope(|scope| {
+        let workers: Vec<_> = (0..REGISTRY_CONCURRENCY.min(checks.len()))
+            .map(|_| {
+                scope.spawn(|| {
+                    let mut done = Vec::new();
+                    loop {
+                        let index = next.fetch_add(1, Ordering::Relaxed);
+                        let Some((_, pkg, expected)) = checks.get(index) else {
+                            return done;
+                        };
+                        let published = fetch_packument(&agent, pkg).map(|packument| {
+                            packument.is_some_and(|packument| {
+                                published_for_definition(&packument, expected, &series)
+                            })
+                        });
+                        done.push((index, published));
+                    }
+                })
+            })
+            .collect();
+        workers
+            .into_iter()
+            .flat_map(|worker| worker.join().expect("npm registry worker panicked"))
+            .collect()
+    });
+    results.sort_by_key(|(index, _)| *index);
+
+    let mut needed = Vec::new();
+    for (index, published) in results {
+        let (wasm_name, pkg, expected) = &checks[index];
+        if !published? {
             eprintln!("Need to publish {pkg} for {expected}");
-            needed.push(wasm_name.to_string());
+            needed.push(wasm_name.clone());
         }
     }
 


### PR DESCRIPTION
`mise run wasm-publish-needed` took minutes, and `mise run langs-gen-catalog` over a minute, because both walked the language list spawning `npm view` one package at a time.

## The problem

`wasm-needed` ran `npm view <pkg> versions --json` once per package (115 of them), then `npm view <pkg>@<version> lumis --json` once per published version in the series to read that version's release marker. That is several hundred sequential subprocesses, each paying node startup plus a registry round trip at roughly 0.65s apiece.

`resolve_published_versions` had the same shape: one `npm view <pkg> version` per package, sequentially, to pin catalog versions.

## The change

The npm registry's full packument is a single document containing every version's `package.json`, about 11KB for a parser package, so one request answers what `npm view` needed N+1 calls to answer. `fetch_packument` retrieves it with `ureq`, already a dependency, and `published_for_definition` scans it in memory.

`dist-tags.latest` in that same document is exactly what `npm view <pkg> version` prints, so the catalog generator shares the fetch rather than keeping a second way to ask.

`fetch_packuments` fetches 16 packages concurrently and returns results in the order requested, so both callers keep deterministic output.

| command | before | after |
| --- | --- | --- |
| `mise run wasm-publish-needed` | minutes | ~2s |
| `mise run langs-gen-catalog` | ~75s+ | ~4s |

## Behavior changes

- A 404 still means "not published, needs publishing". Other registry failures now abort with a message instead of being silently reported as "needs publishing" for every package, which previously could tell CI to rebuild all 115.
- Requests retry up to three times with a short backoff. A transient DNS failure showed up while testing, and 16 concurrent lookups make one more likely; `npm` used to absorb these.
- The `detect` job's `setup-node` is removed. It existed only so `npm view` would run, and nothing in that job invokes npm now.

## Verification

- `cargo clippy --all-targets`, `cargo fmt --check`, and the crate's 20 tests pass; `actionlint` passes.
- `wasm-needed` reports the same three packages as before: `llvm`, `vim`, `zsh`. Checked against the registry, none has a version carrying a `definitionHash`, so all three are genuinely pre-v3. `rust@0.26.4`'s hash matches what `languages.toml` computes, and it is correctly absent.
- Catalog pins were spot-checked against `npm view` for `angular`, `bash`, and `rust`, and agree exactly.

Note: regenerating the catalog today bumps every pin by one patch, because generation always resolves current `latest` while `--check` deliberately reuses existing pins. That drift predates this PR, so the regenerated `catalog.rs` is not included here. Refreshing the pins is a release decision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved WASM package release checks for more reliable catalog generation and publication detection.
  * Reduced redundant package lookups, helping release workflows complete more efficiently.
  * Added retry handling, timeouts, and controlled parallel processing to improve resilience during registry communication.
  * Improved handling of package versions, publication status, stale metadata, and missing release information.
* **Chores**
  * Simplified release workflow setup by removing an unnecessary runtime configuration step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->