### PR TITLE
fix(rust): pin lumis crate requirements to the workspace version

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -29,6 +29,11 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+
+      - name: Check crate dependency requirements
+        run: mise run check-crate-deps
+
       - name: Determine crate to publish
         id: crate
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -230,9 +230,17 @@ jobs:
   crate-deps:
     name: Crate dependency requirements
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+
       - run: mise run check-crate-deps
 
   lint:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,9 @@ on:
       - "languages.toml"
       - "queries/**"
       - "mise.toml"
+      - "benchmarks/rust/Cargo.toml"
+      - "packages/elixir/lumis/native/lumis_nif/Cargo.toml"
+      - "packages/javascript/lumis/native/Cargo.toml"
       - ".github/workflows/rust.yml"
   pull_request:
     paths:
@@ -25,6 +28,9 @@ on:
       - "languages.toml"
       - "queries/**"
       - "mise.toml"
+      - "benchmarks/rust/Cargo.toml"
+      - "packages/elixir/lumis/native/lumis_nif/Cargo.toml"
+      - "packages/javascript/lumis/native/Cargo.toml"
       - ".github/workflows/rust.yml"
   workflow_dispatch:
 
@@ -221,6 +227,14 @@ jobs:
           fi
 
           echo "All external Tree-sitter scanners use strict-aliasing-safe array headers."
+  crate-deps:
+    name: Crate dependency requirements
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+      - run: mise run check-crate-deps
+
   lint:
     if: >-
       ${{ github.event_name == 'workflow_dispatch' ||

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ A test that skips silently reports the same green as a test that verified someth
 
 ### What the workspace never resolves, it never checks
 
-The root `Cargo.toml` points `path` at every lumis crate and patches the rest through `[patch.crates-io]`. Every build in this repository therefore compiles against the working tree, and the `version` requirement sitting beside each `path` is inert until the crate reaches crates.io. Nothing local can be green or red about it.
+The root `Cargo.toml` points `path` at every lumis crate and patches the rest through `[patch.crates-io]`. Nearly every build in this repository therefore compiles against the working tree, and the `version` requirement sitting beside each `path` is inert until the crate reaches crates.io. Nothing local can be green or red about it. The lone exception is `crates/autumnus`, which sits in its own workspace and depends on `lumis` through the registry.
 
 That is not a gap in the test suite, it is a gap in what a test *could* observe, so it needs a check that reads the manifests rather than builds them. `mise run check-crate-deps` requires each requirement to equal the depended-on crate's version in this repository, and runs in `mise run lint`, in Rust CI, and again before `cargo publish`. `mise run release-prepare` calls it with `--fix`, so releases stay in step without a checklist item.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,17 @@ A test that skips silently reports the same green as a test that verified someth
 - Prove a new guard fails: inject the defect it is meant to catch, watch it go red, then revert. A guard that has never failed has not been tested.
 - Do not let published artifacts gate correctness checks. Build what you need from the pinned source instead, as `mise run test-queries` does, otherwise coverage silently tracks the release cycle.
 
+### What the workspace never resolves, it never checks
+
+The root `Cargo.toml` points `path` at every lumis crate and patches the rest through `[patch.crates-io]`. Every build in this repository therefore compiles against the working tree, and the `version` requirement sitting beside each `path` is inert until the crate reaches crates.io. Nothing local can be green or red about it.
+
+That is not a gap in the test suite, it is a gap in what a test *could* observe, so it needs a check that reads the manifests rather than builds them. `mise run check-crate-deps` requires each requirement to equal the depended-on crate's version in this repository, and runs in `mise run lint`, in Rust CI, and again before `cargo publish`. `mise run release-prepare` calls it with `--fix`, so releases stay in step without a checklist item.
+
+Two things this cost, both worth recognising elsewhere:
+
+- **A too-loose requirement disables the tooling that would maintain it.** `cargo set-version -p lumis-core 2.4.0` rewrites dependents whose requirement the new version falls outside. With `lumis-core = "2"` there was nothing to rewrite, so it stayed `"2"` across three minor releases until `lumis` called an API that `2.0.0` did not have ([#1118](https://github.com/leandrocp/lumis/issues/1118)). Spell requirements in full.
+- **A fresh resolve is not a reproduction.** The failure needed an existing `Cargo.lock`; a new project picked the newest match and worked. When a bug report says "fails on Windows" and the code has no target-specific path, reproduce the reporter's *resolution*, not their OS.
+
 ### Comments are a last resort
 
 Do not narrate code. A comment is justified only when the code is genuinely hard to follow, or when it does something a reader would not expect and would otherwise "fix". Everything else should be carried by naming and structure.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Releases are prepared locally and published from tags.
 - Prepare each release with `mise run release-prepare <package> <version>`.
 - `mise run release-prepare` updates only the target package version file and prepends the next changelog entry.
 - If dependent manifests must move together, update them separately in the same release commit. `npm-lumis` is the exception: it also bumps the native crate, the `@lumis-sh/lumis-native` selector and all five platform packages, because the release workflow publishes them under the same version first.
-- A `version` requirement on a lumis crate must equal that crate's version in this repository. `mise run release-prepare` keeps them in step; `mise run check-crate-deps` reports drift and `--fix` repairs it. No build here exercises those requirements, so that check is the only thing that can catch them. See [Crate version requirements](RELEASE.md#crate-version-requirements).
+- A `version` requirement on a lumis crate must equal that crate's version in this repository. `mise run release-prepare` keeps them in step, rewriting dependent manifests beyond the package being released, so review and commit every file it touches. `mise run check-crate-deps` reports drift and `--fix` repairs it. Apart from `crates/autumnus`, no build here resolves those requirements, so that check is the only thing that can catch them. See [Crate version requirements](RELEASE.md#crate-version-requirements).
 - Maintainers commit the release prep changes, then push package tags such as `cargo-lumis-cli/v0.2.0`.
 - Pushing a package tag triggers the publish workflows.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,7 @@ Releases are prepared locally and published from tags.
 - Prepare each release with `mise run release-prepare <package> <version>`.
 - `mise run release-prepare` updates only the target package version file and prepends the next changelog entry.
 - If dependent manifests must move together, update them separately in the same release commit. `npm-lumis` is the exception: it also bumps the native crate, the `@lumis-sh/lumis-native` selector and all five platform packages, because the release workflow publishes them under the same version first.
+- A `version` requirement on a lumis crate must equal that crate's version in this repository. `mise run release-prepare` keeps them in step; `mise run check-crate-deps` reports drift and `--fix` repairs it. No build here exercises those requirements, so that check is the only thing that can catch them. See [Crate version requirements](RELEASE.md#crate-version-requirements).
 - Maintainers commit the release prep changes, then push package tags such as `cargo-lumis-cli/v0.2.0`.
 - Pushing a package tag triggers the publish workflows.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -43,13 +43,17 @@ repository, spelled in full:
 lumis-core = { path = "../lumis-core", version = "2.3.0", default-features = false }
 ```
 
-Nothing built from this repository can tell you when that requirement goes
-stale. The workspace resolves the lumis crates through `path` entries and the
-root `[patch.crates-io]` table, so local builds, CI, and the Elixir and Node
-addons all compile against the working tree no matter what the requirement says.
-It takes effect only after the crate is on crates.io, and even then only for
-consumers whose `Cargo.lock` already holds an older version — a fresh resolve
-picks the newest match and looks fine.
+Almost nothing built from this repository can tell you when that requirement
+goes stale. Every crate that reaches a lumis crate through a `path` entry
+resolves it there, and the root `[patch.crates-io]` table redirects the rest, so
+local builds, CI, and the Elixir and Node addons compile against the working
+tree no matter what the requirement says. `crates/autumnus` is the one exception:
+it declares its own `[workspace]` and depends on `lumis` through the registry, so
+its requirement is the only one a build here actually resolves.
+
+For everything else the requirement takes effect only after the crate is on
+crates.io, and even then only for consumers whose `Cargo.lock` already holds an
+older version — a fresh resolve picks the newest match and looks fine.
 
 That is how [#1118](https://github.com/leandrocp/lumis/issues/1118) shipped.
 `lumis` 0.12.1 called `lumis_core::formatter::html::open_multi_themes_pre_tag`,
@@ -62,7 +66,7 @@ manual edit. Writing the requirement in full is what makes that work: the
 `cargo set-version` it already ran rewrites dependents only when the new version
 falls outside their requirement, and `"2"` absorbed every 2.x bump silently.
 
-```
+```text
 Upgrading lumis-core from 2.3.0 to 2.4.0
  Updating lumis's dependency from 2.3.0 to 2.4.0
  Updating lumis-cli's dependency from 2.3.0 to 2.4.0
@@ -75,9 +79,13 @@ Upgrading lumis-core from 2.3.0 to 2.4.0
 through the registry, so `release-prepare` follows up with
 `mise run check-crate-deps --fix`, which updates whatever is left:
 
-```
+```text
 packages/elixir/lumis/native/lumis_nif/Cargo.toml: lumis-core 2.3.0 -> 2.4.0
 ```
+
+Both passes edit manifests other than the one being released. Review everything
+`git status` reports and commit it with the release, not just the target
+package's `Cargo.toml` and `CHANGELOG.md`.
 
 `mise run check-crate-deps` reports the same drift instead of fixing it. It runs
 in `mise run lint`, as its own job in Rust CI, and again in `rust-release.yml`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,9 +30,58 @@ git push origin cargo-lumis-cli/v0.2.0
 - Pass the bare version to `mise run release-prepare`, for example `0.2.0`, not `v0.2.0`.
 - Include `v` only in the git tag, for example `cargo-lumis-cli/v0.2.0`.
 - Review each changed manifest and `CHANGELOG.md` after `mise run release-prepare`.
-- If one released package depends on another released package, update the dependent manifest in the same commit.
+- If one released package depends on another released package, update the dependent manifest in the same commit. See [Crate version requirements](#crate-version-requirements).
 - Push package tags in dependency order.
 - Watch the tag-triggered publish workflows after pushing tags.
+
+## Crate version requirements
+
+A `version` requirement on a lumis crate must equal that crate's version in this
+repository, spelled in full:
+
+```toml
+lumis-core = { path = "../lumis-core", version = "2.3.0", default-features = false }
+```
+
+Nothing built from this repository can tell you when that requirement goes
+stale. The workspace resolves the lumis crates through `path` entries and the
+root `[patch.crates-io]` table, so local builds, CI, and the Elixir and Node
+addons all compile against the working tree no matter what the requirement says.
+It takes effect only after the crate is on crates.io, and even then only for
+consumers whose `Cargo.lock` already holds an older version — a fresh resolve
+picks the newest match and looks fine.
+
+That is how [#1118](https://github.com/leandrocp/lumis/issues/1118) shipped.
+`lumis` 0.12.1 called `lumis_core::formatter::html::open_multi_themes_pre_tag`,
+added in `lumis-core` 2.2.0, while requiring `lumis-core = "2"`. Anyone upgrading
+from 0.11 kept the `lumis-core` 2.0.0 or 2.1.0 already in their lockfile and got
+a compile error.
+
+`mise run release-prepare` keeps this current, so a normal release needs no
+manual edit. Writing the requirement in full is what makes that work: the
+`cargo set-version` it already ran rewrites dependents only when the new version
+falls outside their requirement, and `"2"` absorbed every 2.x bump silently.
+
+```
+Upgrading lumis-core from 2.3.0 to 2.4.0
+ Updating lumis's dependency from 2.3.0 to 2.4.0
+ Updating lumis-cli's dependency from 2.3.0 to 2.4.0
+ Updating lumis-js-native's dependency from 2.3.0 to 2.4.0
+ Updating lumis-wasm-runtime's dependency from 2.3.0 to 2.4.0
+```
+
+`cargo set-version` only reaches dependents it can see through `path`.
+`packages/elixir/lumis/native/lumis_nif/Cargo.toml` depends on `lumis-core`
+through the registry, so `release-prepare` follows up with
+`mise run check-crate-deps --fix`, which updates whatever is left:
+
+```
+packages/elixir/lumis/native/lumis_nif/Cargo.toml: lumis-core 2.3.0 -> 2.4.0
+```
+
+`mise run check-crate-deps` reports the same drift instead of fixing it. It runs
+in `mise run lint`, as its own job in Rust CI, and again in `rust-release.yml`
+before `cargo publish`.
 
 ## Publish order
 

--- a/benchmarks/rust/Cargo.toml
+++ b/benchmarks/rust/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.91"
 publish = false
 
 [dependencies]
-lumis = { path = "../../crates/lumis", version = "0.12", default-features = false, features = ["lang-bash", "lang-c", "lang-comment", "lang-elixir", "lang-heex", "lang-markdown", "lang-markdown-inline", "lang-css", "lang-go", "lang-html", "lang-java", "lang-javascript", "lang-json", "lang-python", "lang-ruby", "lang-rust", "lang-tsx"] }
+lumis = { path = "../../crates/lumis", default-features = false, features = ["lang-bash", "lang-c", "lang-comment", "lang-elixir", "lang-heex", "lang-markdown", "lang-markdown-inline", "lang-css", "lang-go", "lang-html", "lang-java", "lang-javascript", "lang-json", "lang-python", "lang-ruby", "lang-rust", "lang-tsx"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 syntect = "5.3"

--- a/crates/dev/src/main.rs
+++ b/crates/dev/src/main.rs
@@ -1741,10 +1741,17 @@ fn is_publishable(document: &toml_edit::DocumentMut) -> bool {
     let Some(package) = document.get("package") else {
         return false;
     };
-    package
-        .get("publish")
-        .and_then(|publish| publish.as_bool())
-        .unwrap_or(true)
+    let Some(publish) = package.get("publish") else {
+        return true;
+    };
+    if let Some(allowed) = publish.as_bool() {
+        return allowed;
+    }
+    // cargo: "`package.publish` must be set to `true` or a non-empty list in
+    // Cargo.toml to publish", so `publish = []` is another spelling of `false`.
+    publish
+        .as_array()
+        .is_none_or(|registries| !registries.is_empty())
 }
 
 fn read_manifests() -> Result<Vec<Manifest>> {
@@ -3887,12 +3894,31 @@ features = ["lang-rust"]
         assert_eq!(inherited, vec![true]);
     }
 
+    fn publishable(manifest: &str) -> bool {
+        is_publishable(&manifest.parse().expect("valid manifest"))
+    }
+
     #[test]
     fn a_manifest_without_a_package_is_not_publishable() {
-        let document: toml_edit::DocumentMut = "[workspace]\nmembers = []\n"
-            .parse()
-            .expect("valid manifest");
-        assert!(!is_publishable(&document));
+        assert!(!publishable("[workspace]\nmembers = []\n"));
+    }
+
+    #[test]
+    fn publish_decides_whether_a_requirement_can_reach_a_registry() {
+        assert!(publishable("[package]\nname = \"example\"\n"));
+        assert!(publishable(
+            "[package]\nname = \"example\"\npublish = true\n"
+        ));
+        assert!(!publishable(
+            "[package]\nname = \"example\"\npublish = false\n"
+        ));
+        // cargo rejects `cargo publish` for both of these.
+        assert!(!publishable(
+            "[package]\nname = \"example\"\npublish = []\n"
+        ));
+        assert!(publishable(
+            "[package]\nname = \"example\"\npublish = [\"crates-io\"]\n"
+        ));
     }
 
     #[test]

--- a/crates/dev/src/main.rs
+++ b/crates/dev/src/main.rs
@@ -1647,9 +1647,26 @@ struct CrateDependency {
     publishable: bool,
 }
 
-fn tracked_cargo_manifests() -> Result<Vec<String>> {
+fn repository_root() -> Result<PathBuf> {
     let output = Command::new("git")
-        .args(["ls-files", "-z", "*Cargo.toml"])
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .context("failed to locate the repository root")?;
+    if !output.status.success() {
+        bail!("git rev-parse --show-toplevel failed; not inside a git repository");
+    }
+
+    Ok(PathBuf::from(
+        String::from_utf8_lossy(&output.stdout).trim(),
+    ))
+}
+
+/// Paths come back relative to the repository root rather than the working
+/// directory, so `CRATE_DEP_WAIVERS` matches wherever this is run from.
+fn tracked_cargo_manifests(root: &Path) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .current_dir(root)
+        .args(["ls-files", "--full-name", "-z", "*Cargo.toml"])
         .output()
         .context("failed to list tracked Cargo manifests")?;
     if !output.status.success() {
@@ -1702,28 +1719,49 @@ fn requirement_of(spec: &toml_edit::Item) -> Option<String> {
     }
 }
 
+/// `{ workspace = true }` carries no requirement of its own, and cargo rejects a
+/// `version` beside it. The `[workspace.dependencies]` entry it inherits from is
+/// itself visited, so the requirement is still checked once.
+fn inherits_from_workspace(spec: &toml_edit::Item) -> bool {
+    spec.get("workspace")
+        .and_then(|workspace| workspace.as_bool())
+        .unwrap_or(false)
+}
+
 struct Manifest {
     path: String,
+    file: PathBuf,
     document: toml_edit::DocumentMut,
     publishable: bool,
 }
 
+fn is_publishable(document: &toml_edit::DocumentMut) -> bool {
+    // A virtual manifest has no package to publish, so a requirement in one can
+    // never reach a registry.
+    let Some(package) = document.get("package") else {
+        return false;
+    };
+    package
+        .get("publish")
+        .and_then(|publish| publish.as_bool())
+        .unwrap_or(true)
+}
+
 fn read_manifests() -> Result<Vec<Manifest>> {
-    tracked_cargo_manifests()?
+    let root = repository_root()?;
+    tracked_cargo_manifests(&root)?
         .into_iter()
         .map(|path| {
+            let file = root.join(&path);
             let text =
-                fs::read_to_string(&path).with_context(|| format!("failed to read {path}"))?;
+                fs::read_to_string(&file).with_context(|| format!("failed to read {path}"))?;
             let document: toml_edit::DocumentMut = text
                 .parse()
                 .with_context(|| format!("failed to parse {path}"))?;
-            let publishable = document
-                .get("package")
-                .and_then(|package| package.get("publish"))
-                .and_then(|publish| publish.as_bool())
-                .unwrap_or(true);
+            let publishable = is_publishable(&document);
             Ok(Manifest {
                 path,
+                file,
                 document,
                 publishable,
             })
@@ -1761,6 +1799,9 @@ fn check_crate_deps(fix: bool) -> Result<()> {
         let path = manifest.path.clone();
         let publishable = manifest.publishable;
         for_each_dependency(manifest.document.as_table_mut(), &mut |name, spec| {
+            if inherits_from_workspace(spec) {
+                return;
+            }
             dependencies.push(CrateDependency {
                 manifest: path.clone(),
                 name: name.to_string(),
@@ -1797,49 +1838,67 @@ fn is_waived(manifest: &str, name: &str) -> bool {
 /// `cargo set-version` rewrites dependents it can reach through `path`. The
 /// Elixir NIF depends on `lumis-core` through the registry, so it is invisible
 /// to that pass and drifts on every release unless something else moves it.
+fn fix_manifest(
+    path: &str,
+    publishable: bool,
+    document: &mut toml_edit::DocumentMut,
+    versions: &BTreeMap<String, String>,
+) -> Vec<String> {
+    let mut changes = Vec::new();
+
+    for_each_dependency(document.as_table_mut(), &mut |name, spec| {
+        let Some(version) = versions.get(name) else {
+            return;
+        };
+        if is_waived(path, name) || inherits_from_workspace(spec) {
+            return;
+        }
+        let previous = requirement_of(spec);
+        // A path dependency in a crate that is never published has nothing to
+        // resolve a requirement against, so do not invent one.
+        if previous.is_none() && !publishable {
+            return;
+        }
+        if previous.as_deref() == Some(version.as_str()) {
+            return;
+        }
+
+        changes.push(format!(
+            "{path}: {name} {} -> {version}",
+            previous.as_deref().unwrap_or("no version")
+        ));
+
+        // Only the requirement moves. Replacing the whole entry would drop the
+        // `path`, `features` and `default-features` beside it.
+        match spec {
+            toml_edit::Item::Value(toml_edit::Value::InlineTable(entry)) => {
+                entry.insert("version", toml_edit::Value::from(version.clone()));
+                entry.fmt();
+            }
+            toml_edit::Item::Table(entry) => {
+                entry["version"] = toml_edit::value(version.clone());
+            }
+            _ => *spec = toml_edit::value(version.clone()),
+        }
+    });
+
+    changes
+}
+
 fn fix_crate_deps(manifests: &mut [Manifest], versions: &BTreeMap<String, String>) -> Result<()> {
     let mut changes = Vec::new();
 
     for manifest in manifests {
-        let path = manifest.path.clone();
-        let publishable = manifest.publishable;
-        let mut changed = false;
-
-        for_each_dependency(manifest.document.as_table_mut(), &mut |name, spec| {
-            let Some(version) = versions.get(name) else {
-                return;
-            };
-            if is_waived(&path, name) {
-                return;
-            }
-            let previous = requirement_of(spec);
-            // A path dependency in a crate that is never published has nothing
-            // to resolve a requirement against, so do not invent one.
-            if previous.is_none() && !publishable {
-                return;
-            }
-            if previous.as_deref() == Some(version.as_str()) {
-                return;
-            }
-
-            changes.push(format!(
-                "{path}: {name} {} -> {version}",
-                previous.as_deref().unwrap_or("no version")
-            ));
-            changed = true;
-
-            match spec {
-                toml_edit::Item::Value(toml_edit::Value::InlineTable(entry)) => {
-                    entry.insert("version", toml_edit::Value::from(version.clone()));
-                    entry.fmt();
-                }
-                _ => *spec = toml_edit::value(version.clone()),
-            }
-        });
-
-        if changed {
-            fs::write(&manifest.path, manifest.document.to_string())
+        let manifest_changes = fix_manifest(
+            &manifest.path,
+            manifest.publishable,
+            &mut manifest.document,
+            versions,
+        );
+        if !manifest_changes.is_empty() {
+            fs::write(&manifest.file, manifest.document.to_string())
                 .with_context(|| format!("failed to write {}", manifest.path))?;
+            changes.extend(manifest_changes);
         }
     }
 
@@ -3728,6 +3787,112 @@ mod crate_dep_tests {
         let reported = crate_dep_problems(&versions(), &dependencies, count).0;
         assert_eq!(reported.len(), 1);
         assert!(reported[0].contains("remove its waiver"), "{reported:?}");
+    }
+
+    fn fixed(manifest: &str) -> String {
+        let mut document: toml_edit::DocumentMut = manifest.parse().expect("valid manifest");
+        fix_manifest(
+            "crates/example/Cargo.toml",
+            true,
+            &mut document,
+            &versions(),
+        );
+        document.to_string()
+    }
+
+    fn collected(manifest: &str) -> Vec<(String, Option<String>)> {
+        let mut document: toml_edit::DocumentMut = manifest.parse().expect("valid manifest");
+        let mut found = Vec::new();
+        for_each_dependency(document.as_table_mut(), &mut |name, spec| {
+            found.push((name.to_string(), requirement_of(spec)));
+        });
+        found
+    }
+
+    #[test]
+    fn target_specific_and_renamed_dependencies_are_visited() {
+        let mut found = collected(
+            r#"
+[dependencies]
+lumis-core = { version = "2.0.0", features = ["all-languages"] }
+
+[target.'cfg(windows)'.dependencies]
+core-alias = { package = "lumis-core", version = "2.1.0" }
+
+[build-dependencies]
+lumis-build = "1.0.0"
+"#,
+        );
+        found.sort();
+
+        assert_eq!(
+            found,
+            vec![
+                ("lumis-build".to_string(), Some("1.0.0".to_string())),
+                ("lumis-core".to_string(), Some("2.0.0".to_string())),
+                // Reached only through `[target.'cfg(windows)'.dependencies]`,
+                // and named by `package = "lumis-core"` rather than its key.
+                ("lumis-core".to_string(), Some("2.1.0".to_string())),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_dependency_table_keeps_its_other_fields() {
+        let fixed = fixed(
+            r#"
+[dependencies.lumis-core]
+path = "../lumis-core"
+version = "2"
+default-features = false
+features = ["lang-rust"]
+"#,
+        );
+
+        assert!(fixed.contains("version = \"2.3.0\""), "{fixed}");
+        assert!(fixed.contains("path = \"../lumis-core\""), "{fixed}");
+        assert!(fixed.contains("default-features = false"), "{fixed}");
+        assert!(fixed.contains("features = [\"lang-rust\"]"), "{fixed}");
+    }
+
+    #[test]
+    fn an_inline_table_keeps_its_other_fields() {
+        let fixed = fixed(
+            "[dependencies]\nlumis-core = { path = \"../lumis-core\", version = \"2\", features = [\"lang-rust\"] }\n",
+        );
+
+        assert!(fixed.contains("version = \"2.3.0\""), "{fixed}");
+        assert!(fixed.contains("path = \"../lumis-core\""), "{fixed}");
+        assert!(fixed.contains("features = [\"lang-rust\"]"), "{fixed}");
+    }
+
+    #[test]
+    fn a_string_requirement_stays_a_string() {
+        assert_eq!(
+            fixed("[dependencies]\nlumis-core = \"2\"\n"),
+            "[dependencies]\nlumis-core = \"2.3.0\"\n"
+        );
+    }
+
+    #[test]
+    fn a_workspace_inherited_dependency_is_left_alone() {
+        let manifest = "[dependencies]\nlumis-core = { workspace = true }\n";
+        assert_eq!(fixed(manifest), manifest);
+
+        let mut document: toml_edit::DocumentMut = manifest.parse().expect("valid manifest");
+        let mut inherited = Vec::new();
+        for_each_dependency(document.as_table_mut(), &mut |_, spec| {
+            inherited.push(inherits_from_workspace(spec));
+        });
+        assert_eq!(inherited, vec![true]);
+    }
+
+    #[test]
+    fn a_manifest_without_a_package_is_not_publishable() {
+        let document: toml_edit::DocumentMut = "[workspace]\nmembers = []\n"
+            .parse()
+            .expect("valid manifest");
+        assert!(!is_publishable(&document));
     }
 
     #[test]

--- a/crates/dev/src/main.rs
+++ b/crates/dev/src/main.rs
@@ -61,6 +61,10 @@ enum Commands {
         name: String,
     },
     CargoUpdateFeatures,
+    CheckCrateDeps {
+        #[arg(long)]
+        fix: bool,
+    },
     PreprocessQueries {
         #[arg(default_value = "")]
         name: String,
@@ -141,6 +145,7 @@ fn main() -> Result<()> {
         Commands::FetchQueries { name } => fetch_queries(&name),
         Commands::CargoUpdateDep { name } => cargo_update_dep(&name),
         Commands::CargoUpdateFeatures => cargo_update_features(),
+        Commands::CheckCrateDeps { fix } => check_crate_deps(fix),
         Commands::PreprocessQueries { name } => preprocess_queries(&name),
         Commands::GenHighlights => gen_highlights(),
         Commands::GenLanguagesMd => gen_languages_md(),
@@ -1610,6 +1615,316 @@ fn cargo_update_features() -> Result<()> {
 
     write_lumis_cargo_toml_edit(&cargo)?;
     write_lumis_core_cargo_toml_edit(&cargo_core)
+}
+
+/// Crates published from this repository that something else here depends on.
+/// Named rather than counted, so a crate that disappears from the workspace
+/// fails here instead of silently shrinking what gets checked.
+const RELEASED_CRATES: &[&str] = &[
+    "lumis",
+    "lumis-build",
+    "lumis-cli",
+    "lumis-core",
+    "lumis-wasm-runtime",
+];
+
+/// Requirements deliberately left behind the workspace, and why. A waiver that
+/// stops being needed has to fail too, so this list can only shrink.
+const CRATE_DEP_WAIVERS: &[(&str, &str, &str)] = &[(
+    "crates/autumnus/Cargo.toml",
+    "lumis",
+    "deprecated rename shim, frozen at the lumis it was published against",
+)];
+
+const DEPENDENCY_TABLES: &[&str] = &["dependencies", "dev-dependencies", "build-dependencies"];
+
+const MIN_CHECKED_CRATE_DEPS: usize = 10;
+
+struct CrateDependency {
+    manifest: String,
+    name: String,
+    requirement: Option<String>,
+    publishable: bool,
+}
+
+fn tracked_cargo_manifests() -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .args(["ls-files", "-z", "*Cargo.toml"])
+        .output()
+        .context("failed to list tracked Cargo manifests")?;
+    if !output.status.success() {
+        bail!("git ls-files failed while listing Cargo manifests");
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .split('\0')
+        .filter(|path| !path.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+/// Visits every dependency entry in a manifest, including the ones nested under
+/// `[target.'cfg(...)'.dependencies]`, with the name of the crate it resolves to.
+fn for_each_dependency(
+    table: &mut toml_edit::Table,
+    visit: &mut impl FnMut(&str, &mut toml_edit::Item),
+) {
+    for (key, item) in table.iter_mut() {
+        if DEPENDENCY_TABLES.contains(&key.get()) {
+            let Some(dependencies) = item.as_table_like_mut() else {
+                continue;
+            };
+            for (dep_key, spec) in dependencies.iter_mut() {
+                // `package = "..."` renames the dependency, so the key is not
+                // necessarily the crate being depended on.
+                let name = spec
+                    .get("package")
+                    .and_then(|package| package.as_str())
+                    .unwrap_or(dep_key.get())
+                    .to_string();
+                visit(&name, spec);
+            }
+        } else if let Some(nested) = item.as_table_mut() {
+            for_each_dependency(nested, visit);
+        }
+    }
+}
+
+fn requirement_of(spec: &toml_edit::Item) -> Option<String> {
+    match spec {
+        toml_edit::Item::Value(toml_edit::Value::String(requirement)) => {
+            Some(requirement.value().clone())
+        }
+        _ => spec
+            .get("version")
+            .and_then(|version| version.as_str())
+            .map(str::to_string),
+    }
+}
+
+struct Manifest {
+    path: String,
+    document: toml_edit::DocumentMut,
+    publishable: bool,
+}
+
+fn read_manifests() -> Result<Vec<Manifest>> {
+    tracked_cargo_manifests()?
+        .into_iter()
+        .map(|path| {
+            let text =
+                fs::read_to_string(&path).with_context(|| format!("failed to read {path}"))?;
+            let document: toml_edit::DocumentMut = text
+                .parse()
+                .with_context(|| format!("failed to parse {path}"))?;
+            let publishable = document
+                .get("package")
+                .and_then(|package| package.get("publish"))
+                .and_then(|publish| publish.as_bool())
+                .unwrap_or(true);
+            Ok(Manifest {
+                path,
+                document,
+                publishable,
+            })
+        })
+        .collect()
+}
+
+/// Every build in this repository resolves the lumis crates through `path`
+/// entries and the root `[patch.crates-io]`, so the `version` requirement
+/// beside them is dead weight locally and only takes effect once the crate is
+/// published. Nothing here can notice it going stale, which is how lumis 0.12.1
+/// shipped requiring `lumis-core = "2"` while calling an API added in 2.2.0
+/// (#1118): consumers resolving from an existing Cargo.lock got 2.0.0 and
+/// failed to compile.
+fn check_crate_deps(fix: bool) -> Result<()> {
+    let mut manifests = read_manifests()?;
+
+    let versions: BTreeMap<String, String> = manifests
+        .iter()
+        .filter_map(|manifest| {
+            let package = manifest.document.get("package")?;
+            Some((
+                package.get("name")?.as_str()?.to_string(),
+                package.get("version")?.as_str()?.to_string(),
+            ))
+        })
+        .collect();
+
+    if fix {
+        return fix_crate_deps(&mut manifests, &versions);
+    }
+
+    let mut dependencies = Vec::new();
+    for manifest in &mut manifests {
+        let path = manifest.path.clone();
+        let publishable = manifest.publishable;
+        for_each_dependency(manifest.document.as_table_mut(), &mut |name, spec| {
+            dependencies.push(CrateDependency {
+                manifest: path.clone(),
+                name: name.to_string(),
+                requirement: requirement_of(spec),
+                publishable,
+            });
+        });
+    }
+
+    let (problems, checked) = crate_dep_problems(&versions, &dependencies, manifests.len());
+
+    if !problems.is_empty() {
+        for problem in &problems {
+            eprintln!("  {problem}");
+        }
+        bail!(
+            "version requirements on lumis crates must equal the version in this repository.\n\
+             Run `mise run check-crate-deps --fix` to update them."
+        );
+    }
+
+    println!("{checked} lumis dependencies match the workspace versions");
+    Ok(())
+}
+
+fn is_waived(manifest: &str, name: &str) -> bool {
+    CRATE_DEP_WAIVERS
+        .iter()
+        .any(|(waived_manifest, waived_name, _)| {
+            *waived_manifest == manifest && *waived_name == name
+        })
+}
+
+/// `cargo set-version` rewrites dependents it can reach through `path`. The
+/// Elixir NIF depends on `lumis-core` through the registry, so it is invisible
+/// to that pass and drifts on every release unless something else moves it.
+fn fix_crate_deps(manifests: &mut [Manifest], versions: &BTreeMap<String, String>) -> Result<()> {
+    let mut changes = Vec::new();
+
+    for manifest in manifests {
+        let path = manifest.path.clone();
+        let publishable = manifest.publishable;
+        let mut changed = false;
+
+        for_each_dependency(manifest.document.as_table_mut(), &mut |name, spec| {
+            let Some(version) = versions.get(name) else {
+                return;
+            };
+            if is_waived(&path, name) {
+                return;
+            }
+            let previous = requirement_of(spec);
+            // A path dependency in a crate that is never published has nothing
+            // to resolve a requirement against, so do not invent one.
+            if previous.is_none() && !publishable {
+                return;
+            }
+            if previous.as_deref() == Some(version.as_str()) {
+                return;
+            }
+
+            changes.push(format!(
+                "{path}: {name} {} -> {version}",
+                previous.as_deref().unwrap_or("no version")
+            ));
+            changed = true;
+
+            match spec {
+                toml_edit::Item::Value(toml_edit::Value::InlineTable(entry)) => {
+                    entry.insert("version", toml_edit::Value::from(version.clone()));
+                    entry.fmt();
+                }
+                _ => *spec = toml_edit::value(version.clone()),
+            }
+        });
+
+        if changed {
+            fs::write(&manifest.path, manifest.document.to_string())
+                .with_context(|| format!("failed to write {}", manifest.path))?;
+        }
+    }
+
+    if changes.is_empty() {
+        println!("no crate dependency requirements needed updating");
+    }
+    for change in &changes {
+        println!("  {change}");
+    }
+
+    check_crate_deps(false)
+}
+
+fn crate_dep_problems(
+    versions: &BTreeMap<String, String>,
+    dependencies: &[CrateDependency],
+    manifest_count: usize,
+) -> (Vec<String>, usize) {
+    let mut problems = Vec::new();
+
+    for name in RELEASED_CRATES {
+        if !versions.contains_key(*name) {
+            problems.push(format!("{name}: no manifest in this repository defines it"));
+        }
+    }
+
+    let mut waivers_used = HashSet::new();
+    let mut checked = 0;
+
+    for dependency in dependencies {
+        let Some(version) = versions.get(&dependency.name) else {
+            continue;
+        };
+        checked += 1;
+
+        let waiver = CRATE_DEP_WAIVERS.iter().find(|(manifest, name, _)| {
+            *manifest == dependency.manifest && *name == dependency.name
+        });
+
+        if let Some((manifest, name, reason)) = waiver {
+            waivers_used.insert((*manifest, *name));
+            if dependency.requirement.as_deref() == Some(version.as_str()) {
+                problems.push(format!(
+                    "{manifest}: {name} = \"{version}\" now matches the workspace, \
+                     so the waiver ({reason}) is obsolete and must be removed"
+                ));
+            }
+            continue;
+        }
+
+        match &dependency.requirement {
+            Some(requirement) if requirement == version => {}
+            Some(requirement) => problems.push(format!(
+                "{}: {} = \"{requirement}\", expected \"{version}\"",
+                dependency.manifest, dependency.name
+            )),
+            // A path dependency with no version is fine until the crate holding
+            // it is published, at which point cargo strips the path and has
+            // nothing left to resolve.
+            None if dependency.publishable => problems.push(format!(
+                "{}: {} declares no version, so publishing it would drop the dependency",
+                dependency.manifest, dependency.name
+            )),
+            None => {}
+        }
+    }
+
+    for (manifest, name, _) in CRATE_DEP_WAIVERS {
+        if !waivers_used.contains(&(*manifest, *name)) {
+            problems.push(format!(
+                "{manifest}: waived dependency {name} is gone, remove its waiver"
+            ));
+        }
+    }
+
+    // A glob or a `git ls-files` that stops matching would otherwise report the
+    // same success as a repository with no drift.
+    if checked < MIN_CHECKED_CRATE_DEPS {
+        problems.push(format!(
+            "only {checked} lumis dependencies found across {manifest_count} manifests, \
+             expected at least {MIN_CHECKED_CRATE_DEPS}"
+        ));
+    }
+
+    (problems, checked)
 }
 
 fn fetch_queries(name: &str) -> Result<()> {
@@ -3300,6 +3615,138 @@ fn wasm_needed(filter: &str, force: &str) -> Result<()> {
 
 fn wasm_package_suffix(wasm_name: &str) -> &str {
     wasm_name.strip_prefix("tree-sitter-").unwrap_or(wasm_name)
+}
+
+#[cfg(test)]
+mod crate_dep_tests {
+    use super::*;
+
+    fn versions() -> BTreeMap<String, String> {
+        RELEASED_CRATES
+            .iter()
+            .map(|name| (name.to_string(), "2.3.0".to_string()))
+            .collect()
+    }
+
+    fn dependency(manifest: &str, requirement: Option<&str>) -> CrateDependency {
+        CrateDependency {
+            manifest: manifest.to_string(),
+            name: "lumis-core".to_string(),
+            requirement: requirement.map(str::to_string),
+            publishable: true,
+        }
+    }
+
+    /// The waived entry keeps every case above the corpus floor, so a real
+    /// problem is what fails rather than the sanity check underneath it.
+    fn padding() -> Vec<CrateDependency> {
+        let (manifest, name, _) = CRATE_DEP_WAIVERS[0];
+        let mut dependencies = vec![CrateDependency {
+            manifest: manifest.to_string(),
+            name: name.to_string(),
+            requirement: Some("0.0.1".to_string()),
+            publishable: true,
+        }];
+        dependencies.extend(
+            (0..MIN_CHECKED_CRATE_DEPS)
+                .map(|index| dependency(&format!("c{index}"), Some("2.3.0"))),
+        );
+        dependencies
+    }
+
+    fn problems(extra: Vec<CrateDependency>) -> Vec<String> {
+        let mut dependencies = padding();
+        dependencies.extend(extra);
+        let count = dependencies.len();
+        crate_dep_problems(&versions(), &dependencies, count).0
+    }
+
+    #[test]
+    fn matching_requirements_are_accepted() {
+        assert!(problems(Vec::new()).is_empty());
+    }
+
+    #[test]
+    fn a_requirement_below_the_workspace_version_is_reported() {
+        let reported = problems(vec![dependency("crates/lumis/Cargo.toml", Some("2"))]);
+        assert_eq!(reported.len(), 1);
+        assert!(
+            reported[0].contains("lumis-core = \"2\", expected \"2.3.0\""),
+            "{reported:?}"
+        );
+    }
+
+    #[test]
+    fn a_newer_requirement_than_the_workspace_is_reported() {
+        assert_eq!(
+            problems(vec![dependency("crates/lumis/Cargo.toml", Some("2.4.0"))]).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn a_publishable_crate_must_declare_a_version() {
+        let reported = problems(vec![dependency("crates/lumis/Cargo.toml", None)]);
+        assert_eq!(reported.len(), 1);
+        assert!(reported[0].contains("declares no version"), "{reported:?}");
+    }
+
+    #[test]
+    fn an_unpublished_crate_may_omit_the_version() {
+        let mut unpublished = dependency("benchmarks/rust/Cargo.toml", None);
+        unpublished.publishable = false;
+        assert!(problems(vec![unpublished]).is_empty());
+    }
+
+    #[test]
+    fn a_waiver_that_stopped_drifting_is_reported() {
+        let (manifest, name, _) = CRATE_DEP_WAIVERS[0];
+        let mut dependencies: Vec<CrateDependency> = padding()
+            .into_iter()
+            .filter(|dependency| dependency.manifest != manifest)
+            .collect();
+        dependencies.push(CrateDependency {
+            manifest: manifest.to_string(),
+            name: name.to_string(),
+            requirement: Some("2.3.0".to_string()),
+            publishable: true,
+        });
+        let count = dependencies.len();
+        let reported = crate_dep_problems(&versions(), &dependencies, count).0;
+        assert_eq!(reported.len(), 1);
+        assert!(reported[0].contains("obsolete"), "{reported:?}");
+    }
+
+    #[test]
+    fn a_waiver_whose_dependency_is_gone_is_reported() {
+        let (manifest, _, _) = CRATE_DEP_WAIVERS[0];
+        let dependencies: Vec<CrateDependency> = padding()
+            .into_iter()
+            .filter(|dependency| dependency.manifest != manifest)
+            .collect();
+        let count = dependencies.len();
+        let reported = crate_dep_problems(&versions(), &dependencies, count).0;
+        assert_eq!(reported.len(), 1);
+        assert!(reported[0].contains("remove its waiver"), "{reported:?}");
+    }
+
+    #[test]
+    fn discovery_that_finds_nothing_fails() {
+        let (reported, checked) = crate_dep_problems(&BTreeMap::new(), &[], 0);
+        assert_eq!(checked, 0);
+        assert!(
+            reported
+                .iter()
+                .any(|problem| problem.contains("expected at least")),
+            "{reported:?}"
+        );
+        for name in RELEASED_CRATES {
+            assert!(
+                reported.iter().any(|problem| problem.starts_with(name)),
+                "{name} not reported missing: {reported:?}"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/lumis-cli/Cargo.toml
+++ b/crates/lumis-cli/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-lumis-core = { path = "../lumis-core", version = "2", features = ["all-languages"] }
+lumis-core = { path = "../lumis-core", version = "2.3.0", features = ["all-languages"] }
 lumis-wasm-runtime = { path = "../lumis-wasm-runtime", version = "0.1.0" }
 tree-sitter = { version = "^0.26.9", features = ["wasm"] }
 wasmtime = { version = "36", default-features = false, features = ["cache", "cranelift", "runtime", "std"] }

--- a/crates/lumis-wasm-runtime/Cargo.toml
+++ b/crates/lumis-wasm-runtime/Cargo.toml
@@ -16,7 +16,7 @@ wasm = ["dep:lumis-core", "dep:wasmtime", "dep:ureq", "dep:typed-arena", "tree-s
 [dependencies]
 typed-arena = { version = "2", optional = true }
 ureq = { version = "3", optional = true }
-lumis-core = { path = "../lumis-core", version = "2", default-features = false, optional = true }
+lumis-core = { path = "../lumis-core", version = "2.3.0", default-features = false, optional = true }
 streaming-iterator = "0.1"
 thiserror = "2"
 tree-sitter = "^0.26.9"

--- a/crates/lumis/Cargo.toml
+++ b/crates/lumis/Cargo.toml
@@ -283,7 +283,7 @@ lang-zig = ["dep:tree-sitter-zig", "lumis-core/lang-zig"]
 lang-zsh = ["dep:tree-sitter-zsh", "lumis-core/lang-zsh"]
 
 [dependencies]
-lumis-core = { path = "../lumis-core", version = "2", default-features = false }
+lumis-core = { path = "../lumis-core", version = "2.3.0", default-features = false }
 lumis-wasm-runtime = { path = "../lumis-wasm-runtime", version = "0.1.0", default-features = false }
 anyhow = "1.0"
 derive_builder = "0.20"

--- a/mise.toml
+++ b/mise.toml
@@ -366,6 +366,9 @@ mise run fmt-lua -- --check
 echo ""
 echo "Checking native package versions..."
 mise run check-native-versions
+echo ""
+echo "Checking crate dependency requirements..."
+mise run check-crate-deps
 '''
 
 [tasks.'check-native-versions']
@@ -374,6 +377,21 @@ run = '''
 #!/usr/bin/env bash
 set -euo pipefail
 node packages/javascript/scripts/check-native-versions.mjs
+'''
+
+[tasks.'check-crate-deps']
+description = "Check version requirements on lumis crates match the versions in this repository"
+usage = '''
+flag "--fix" help="Rewrite stale requirements instead of reporting them"
+'''
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${usage_fix:-false}" = "true" ]; then
+    cargo run --quiet --manifest-path crates/dev/Cargo.toml -- check-crate-deps --fix
+else
+    cargo run --quiet --manifest-path crates/dev/Cargo.toml -- check-crate-deps
+fi
 '''
 
 [tasks.'fmt']
@@ -1036,6 +1054,7 @@ esac
 case "$kind" in
     cargo)
         cargo set-version --manifest-path "$manifest" -p "$cargo_package" "$version"
+        cargo run --quiet --manifest-path crates/dev/Cargo.toml -- check-crate-deps --fix
         ;;
     npm)
         npm --prefix "$(dirname "$manifest")" version --no-git-tag-version "$version"

--- a/mise.toml
+++ b/mise.toml
@@ -1054,7 +1054,7 @@ esac
 case "$kind" in
     cargo)
         cargo set-version --manifest-path "$manifest" -p "$cargo_package" "$version"
-        cargo run --quiet --manifest-path crates/dev/Cargo.toml -- check-crate-deps --fix
+        mise run check-crate-deps --fix
         ;;
     npm)
         npm --prefix "$(dirname "$manifest")" version --no-git-tag-version "$version"

--- a/packages/elixir/lumis/examples/rainbow_brackets.livemd
+++ b/packages/elixir/lumis/examples/rainbow_brackets.livemd
@@ -2,7 +2,7 @@
 
 ```elixir
 Mix.install([
-  {:lumis, path: "/Users/leandro/code/leandrocp/lumis/trees/main/packages/elixir/lumis"}
+  {:lumis, "~> 0.3"}
 ])
 ```
 

--- a/packages/elixir/lumis/examples/rainbow_brackets.livemd
+++ b/packages/elixir/lumis/examples/rainbow_brackets.livemd
@@ -2,7 +2,7 @@
 
 ```elixir
 Mix.install([
-  {:lumis, "~> 0.3"}
+  {:lumis, path: "/Users/leandro/code/leandrocp/lumis/trees/main/packages/elixir/lumis"}
 ])
 ```
 

--- a/packages/elixir/lumis/native/lumis_nif/Cargo.toml
+++ b/packages/elixir/lumis/native/lumis_nif/Cargo.toml
@@ -14,9 +14,9 @@ crate-type = ["cdylib"]
 once_cell = "1.21"
 parking_lot = "0.12"
 rustler = "0.38"
-lumis-core = { version = "2.3", default-features = false, features = ["all-languages"] }
+lumis-core = { version = "2.3.0", default-features = false, features = ["all-languages"] }
 etcetera = "0.11"
-lumis-wasm-runtime = "0.1"
+lumis-wasm-runtime = "0.1.0"
 
 [features]
 default = ["nif_version_2_15"]

--- a/packages/javascript/lumis/native/Cargo.toml
+++ b/packages/javascript/lumis/native/Cargo.toml
@@ -15,8 +15,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 base64 = "0.22"
-lumis-core = { path = "../../../../crates/lumis-core", version = "2", features = ["all-languages"] }
-lumis-wasm-runtime = { path = "../../../../crates/lumis-wasm-runtime", version = "0.1" }
+lumis-core = { path = "../../../../crates/lumis-core", version = "2.3.0", features = ["all-languages"] }
+lumis-wasm-runtime = { path = "../../../../crates/lumis-wasm-runtime", version = "0.1.0" }
 etcetera = "0.11"
 napi = { version = "3", default-features = false, features = ["napi8", "serde-json"] }
 napi-derive = "3"


### PR DESCRIPTION
Fixes the root cause of #1118 and adds the check that could have caught it.

## The bug

`lumis` 0.12.1 calls `lumis_core::formatter::html::open_multi_themes_pre_tag`, added in `lumis-core` **2.2.0**, while declaring `lumis-core = "2"`. `^2` permits 2.0.0.

It is not a Windows bug. I reproduced the reporter's exact error on Linux:

| lumis-core | result |
| --- | --- |
| 2.0.0 (the reporter's) | `error[E0425]: cannot find function open_multi_themes_pre_tag` |
| 2.1.0 | same |
| fresh resolve → 2.3.0 | builds |

The trigger is a stale lockfile. `lumis` 0.10.0 shipped alongside `lumis-core` 2.0.0 and 0.11.0 three minutes after 2.1.0, so existing projects have one of those pinned. Bumping `lumis` to `"0.12"` leaves `lumis-core` alone because `^2` is still satisfied.

Current `main` still declares `"2"` and still makes the call, so the next release would ship the same trap. I verified that by packaging `crates/lumis` from `main` and building it against pinned versions: fails on 2.1.0, clean on 2.2.0.

## Why nothing caught it

Every build in this repository resolves the lumis crates through `path` and the root `[patch.crates-io]`. The `version` beside each `path` is inert locally and only takes effect once the crate is on crates.io. CI cannot be red about it, and a new consumer resolves the newest 2.x and looks fine.

## The fix

Requirements now equal the crate's version in this repository, spelled in full. That also puts `cargo set-version` back in charge — it rewrites dependents only when the new version falls outside their requirement, so `"2"` absorbed every 2.x bump silently:

```
$ cargo set-version -p lumis-core 2.4.0
   Upgrading lumis-core from 2.3.0 to 2.4.0
    Updating lumis's dependency from 2.3.0 to 2.4.0
    Updating lumis-cli's dependency from 2.3.0 to 2.4.0
    Updating lumis-js-native's dependency from 2.3.0 to 2.4.0
    Updating lumis-wasm-runtime's dependency from 2.3.0 to 2.4.0
```

`release-prepare` already runs that, so releases now stay in step on their own. It reaches only `path` dependents, so it follows up with `check-crate-deps --fix` for `packages/elixir/lumis/native/lumis_nif/Cargo.toml`, which depends on `lumis-core` through the registry.

`benchmarks/rust` had `version = "0.12"` on a `path` dep in a `publish = false` crate. That requirement can never be resolved, so it is dropped rather than pinned.

## The guard

`mise run check-crate-deps` reads the manifests instead of building them, and fails on:

- a requirement that is not the workspace version
- a publishable crate omitting the version on a lumis dependency
- a waived requirement that has caught up, or whose dependency is gone
- discovery finding fewer than 10 dependencies, so a broken `git ls-files` cannot report green

It runs in `mise run lint`, as its own job in Rust CI, and in `rust-release.yml` before `cargo publish`. `--fix` rewrites instead of reporting.

Each failure mode was proven by injecting the defect and watching it go red:

```
crates/lumis/Cargo.toml: lumis-core = "2", expected "2.3.0"
crates/lumis-cli/Cargo.toml: lumis-core = "9.9.9", expected "2.3.0"
crates/lumis/Cargo.toml: lumis-core declares no version, so publishing it would drop the dependency
crates/autumnus/Cargo.toml: lumis = "0.12.1" now matches the workspace, so the waiver is obsolete
packages/elixir/lumis/native/lumis_nif/Cargo.toml: lumis-core = "2.2", expected "2.3.0"
```

Eight unit tests cover the same rules in `crates/dev`.

## Notes

- The one waiver is `crates/autumnus`, a deprecated rename shim pinned at `lumis = "0.1.0"`. I left it frozen because bumping it would change what a future `autumnus` release re-exports. Say the word and I will drop the waiver and pin it like everything else, which removes that machinery.
- This only protects future releases. `lumis` 0.12.1 stays broken on crates.io for stale lockfiles; closing #1118 for users needs a 0.12.2 with the corrected requirement. `cargo update -p lumis-core` is the workaround in the meantime.
- `benchmarks/rust/Cargo.lock` is stale on `main` since the syn 3.0.3 bump (5f8741f), unrelated to this change and left alone.

## Verification

- `mise run check-crate-deps` — 15 dependencies checked
- `cargo test --manifest-path crates/dev/Cargo.toml --no-default-features` — 33 passed
- `cargo clippy --manifest-path crates/dev/Cargo.toml --all-targets -- -D warnings` — clean
- `cargo fmt --manifest-path crates/dev/Cargo.toml --check`
- `mise run lint-workflows`
- simulated `release-prepare cargo-lumis-core 2.4.0` end to end and confirmed all five manifests land on 2.4.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dependency-version validation with reporting and an optional automatic repair mode.
  - Release preparation can synchronize crate dependency requirements automatically.

- **Bug Fixes**
  - Updated dependency requirements to match current package versions, reducing stale release metadata.

- **CI Improvements**
  - Dependency checks now run during linting, continuous integration, and release publishing workflows.

- **Documentation**
  - Expanded contributor and release guidance covering dependency versions, release order, validation, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->