### PR TITLE
fix(elixir)!: align the default theme on none across runtimes

### DIFF
--- a/crates/lumis/examples/auto_detect_language.rs
+++ b/crates/lumis/examples/auto_detect_language.rs
@@ -3,7 +3,7 @@
 //! This example demonstrates using `Language::guess()` to detect the
 //! programming language from a file extension or source code content.
 
-use lumis::{highlight, languages::Language, HtmlInlineBuilder};
+use lumis::{highlight, languages::Language, themes, HtmlInlineBuilder};
 
 fn main() {
     let code = r#"#!/usr/bin/env python3
@@ -20,8 +20,11 @@ print(fibonacci(10))
     // The source code is used for shebang detection if no file extension matches.
     let lang = Language::guess(None, code);
 
+    let theme = themes::get("onedark").expect("onedark theme should be available");
+
     let formatter = HtmlInlineBuilder::new()
         .language(lang)
+        .theme(Some(theme))
         .build()
         .expect("Failed to build formatter");
 

--- a/crates/lumis/src/lib.rs
+++ b/crates/lumis/src/lib.rs
@@ -346,12 +346,13 @@ pub use crate::formatters::{
 /// # Examples
 ///
 /// ```rust
-/// use lumis::{highlight, HtmlInlineBuilder, languages::Language};
+/// use lumis::{highlight, HtmlInlineBuilder, languages::Language, themes};
 ///
 /// let code = r#"fn main() { println!("Hello!"); }"#;
 ///
 /// let formatter = HtmlInlineBuilder::new()
 ///     .language(Language::Rust)
+///     .theme(Some(themes::get("onedark").unwrap()))
 ///     .build()
 ///     .unwrap();
 ///
@@ -379,12 +380,13 @@ pub fn highlight<F: Formatter>(source: &str, formatter: F) -> String {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use lumis::{write_highlight, HtmlInlineBuilder, languages::Language};
+/// use lumis::{write_highlight, HtmlInlineBuilder, languages::Language, themes};
 /// use std::fs::File;
 ///
 /// let code = "fn main() { }";
 /// let formatter = HtmlInlineBuilder::new()
 ///     .language(Language::Rust)
+///     .theme(Some(themes::get("onedark").unwrap()))
 ///     .build()
 ///     .unwrap();
 ///

--- a/docs/content/recipes/stream-output-to-a-file-rust.mdx
+++ b/docs/content/recipes/stream-output-to-a-file-rust.mdx
@@ -8,11 +8,12 @@ description: Write highlighted output directly to a file in Rust.
 # Stream output to a file (Rust)
 
 ```rust
-use lumis::{write_highlight, HtmlInlineBuilder, languages::Language};
+use lumis::{write_highlight, HtmlInlineBuilder, languages::Language, themes};
 use std::fs::File;
 
 let formatter = HtmlInlineBuilder::new()
     .language(Language::Rust)
+    .theme(Some(themes::get("onedark").unwrap()))
     .build()
     .unwrap();
 

--- a/docs/content/usage/elixir-integration.mdx
+++ b/docs/content/usage/elixir-integration.mdx
@@ -18,11 +18,14 @@ keywords:
 Use [`highlight/2`](https://hexdocs.pm/lumis/Lumis.html#highlight/2) when invalid user input, formatter options, or language detection should stay in the normal control flow.
 
 ```elixir
-case Lumis.highlight(source, formatter: {:html_inline, language: "elixir"}) do
+case Lumis.highlight(source, formatter: {:html_inline, language: "elixir", theme: "github_light"}) do
   {:ok, html} -> html
   {:error, reason} -> handle_error(reason)
 end
 ```
+
+There is no default theme. Without `:theme`, `:html_inline` and `:terminal` emit
+uncolored output.
 
 `highlight/2` returns `{:ok, output}` or `{:error, reason}`.
 
@@ -31,7 +34,7 @@ end
 Use [`highlight!/2`](https://hexdocs.pm/lumis/Lumis.html#highlight!/2) when failures should raise immediately, such as in scripts, trusted internal code, or examples.
 
 ```elixir
-html = Lumis.highlight!(source, formatter: {:html_inline, language: "elixir"})
+html = Lumis.highlight!(source, formatter: {:html_inline, language: "elixir", theme: "github_light"})
 ```
 
 `highlight!/2` returns the highlighted output or raises.
@@ -64,7 +67,7 @@ Lumis.highlight!("""
 defmodule Demo do
 end
 ```
-""", formatter: {:html_inline, language: "markdown"})
+""", formatter: {:html_inline, language: "markdown", theme: "github_light"})
 ````
 
 A language that cannot be fetched leaves its own block plain rather than failing
@@ -163,7 +166,7 @@ See [`Lumis`](https://hexdocs.pm/lumis/Lumis.html) and [`Lumis.Theme`](https://h
 Highlighted HTML must be rendered as raw HTML in templates.
 
 ```elixir
-code = Lumis.highlight!(source, formatter: {:html_inline, language: "elixir"})
+code = Lumis.highlight!(source, formatter: {:html_inline, language: "elixir", theme: "github_light"})
 ```
 
 ```heex

--- a/docs/content/usage/rust-advanced.mdx
+++ b/docs/content/usage/rust-advanced.mdx
@@ -18,10 +18,11 @@ keywords:
 Use [`highlight()`](https://docs.rs/lumis/latest/lumis/fn.highlight.html) when you want the rendered output in memory as a `String`.
 
 ```rust
-use lumis::{highlight, HtmlInlineBuilder, languages::Language};
+use lumis::{highlight, HtmlInlineBuilder, languages::Language, themes};
 
 let formatter = HtmlInlineBuilder::new()
     .language(Language::Rust)
+    .theme(Some(themes::get("onedark").unwrap()))
     .build()
     .unwrap();
 
@@ -33,11 +34,12 @@ let html = highlight("fn main() {}", formatter);
 Use [`write_highlight()`](https://docs.rs/lumis/latest/lumis/fn.write_highlight.html) when you want to stream into a file, socket, or other writer without building a large intermediate string.
 
 ```rust
-use lumis::{write_highlight, HtmlInlineBuilder, languages::Language};
+use lumis::{write_highlight, HtmlInlineBuilder, languages::Language, themes};
 use std::fs::File;
 
 let formatter = HtmlInlineBuilder::new()
     .language(Language::Rust)
+    .theme(Some(themes::get("onedark").unwrap()))
     .build()
     .unwrap();
 

--- a/packages/elixir/lumis/README.md
+++ b/packages/elixir/lumis/README.md
@@ -48,12 +48,13 @@ end
 ## Usage
 
 ```elixir
-iex> Lumis.highlight!("Atom.to_string(:elixir)", formatter: {:html_inline, language: "elixir"})
+iex> Lumis.highlight!("Atom.to_string(:elixir)", formatter: {:html_inline, language: "elixir", theme: "github_light"})
 ```
 
 The language is optional — Lumis detects it from the source, a filename, or a
-shebang. Themes are named: `theme: "github_light"`, or a `Lumis.Theme` struct
-built from your own JSON.
+shebang. The theme is optional too, but there is no default: without one,
+`:html_inline` emits spans with no colors. Themes are named:
+`theme: "github_light"`, or a `Lumis.Theme` struct built from your own JSON.
 
 Formatters decide the output: `:html_inline`, `:html_linked`,
 `:html_multi_themes`, `:terminal`, `:bbcode_scoped`, or your own.

--- a/packages/elixir/lumis/lib/lumis.ex
+++ b/packages/elixir/lumis/lib/lumis.ex
@@ -9,8 +9,6 @@ defmodule Lumis do
   require Logger
   alias Lumis.Theme
 
-  @default_theme "onedark"
-
   @typedoc """
   A language name, filename, or path with extension.
 
@@ -151,6 +149,9 @@ defmodule Lumis do
 
       :html_inline
 
+  There is no default theme, so this emits `<span>` tags without any `style` attribute.
+  Pass `:theme` to get colors, or use `:html_linked` to style the output with a CSS file.
+
   ### Inline HTML formatter with custom options
 
       {:html_inline, theme: "onedark", pre_class: "example-01", include_highlights: true}
@@ -158,19 +159,19 @@ defmodule Lumis do
   ### HTML Inline: highlight specific lines
 
       # apply theme's `highlighted` style
-      {:html_inline, highlight_lines: %{lines: [2..4, 6], style: :theme}}
+      {:html_inline, theme: "onedark", highlight_lines: %{lines: [2..4, 6], style: :theme}}
 
       # style: :theme is the default
-      {:html_inline, highlight_lines: %{lines: [1, 2, 3]}}
+      {:html_inline, theme: "onedark", highlight_lines: %{lines: [1, 2, 3]}}
 
       # explicitly use theme style
-      {:html_inline, highlight_lines: %{lines: [1, 2, 3], style: :theme}}
+      {:html_inline, theme: "onedark", highlight_lines: %{lines: [1, 2, 3], style: :theme}}
 
       # overrides default style
-      {:html_inline, highlight_lines: %{lines: [1, 3..5, 8], style: "background-color: #fff3cd; border-left: 3px solid #ffc107;"}}
+      {:html_inline, theme: "onedark", highlight_lines: %{lines: [1, 3..5, 8], style: "background-color: #fff3cd; border-left: 3px solid #ffc107;"}}
 
       # with only class and no style
-      {:html_inline, highlight_lines: %{lines: [1, 2, 3], style: nil, class: "transition-colors duration-500 w-full inline-block bg-yellow-500"}}
+      {:html_inline, theme: "onedark", highlight_lines: %{lines: [1, 2, 3], style: nil, class: "transition-colors duration-500 w-full inline-block bg-yellow-500"}}
 
   ### HTML Linked: highlight specific lines
 
@@ -186,7 +187,7 @@ defmodule Lumis do
         open_tag: "<div class=\"code-header\"><span>file: app.ex</span>",
         close_tag: "</div>"
       }
-      {:html_inline, header: header}
+      {:html_inline, theme: "onedark", header: header}
 
   ### HTML Multi-Themes: Light/Dark mode support
 
@@ -279,7 +280,7 @@ defmodule Lumis do
     type: {:custom, Lumis, :formatter_type, []},
     type_spec: quote(do: Lumis.formatter()),
     type_doc: "`t:Lumis.formatter/0`",
-    default: {:html_inline, theme: "onedark"},
+    default: {:html_inline, []},
     doc: "Formatter to apply on the highlighted source code. See the type doc for more info."
   ]
 
@@ -327,7 +328,7 @@ defmodule Lumis do
   def formatter_type({:html_inline, options}) when is_list(options) do
     schema = [
       language: [type: {:or, [:string, nil]}, default: nil],
-      theme: [type: {:or, [{:struct, Lumis.Theme}, :string, nil]}, default: @default_theme],
+      theme: [type: {:or, [{:struct, Lumis.Theme}, :string, nil]}, default: nil],
       pre_class: [type: {:or, [:string, nil]}, default: nil],
       italic: [type: :boolean, default: false],
       include_highlights: [type: :boolean, default: false],
@@ -489,7 +490,7 @@ defmodule Lumis do
   def formatter_type({:terminal, options}) when is_list(options) do
     schema = [
       language: [type: {:or, [:string, nil]}, default: nil],
-      theme: [type: {:or, [{:struct, Lumis.Theme}, :string, nil]}, default: @default_theme],
+      theme: [type: {:or, [{:struct, Lumis.Theme}, :string, nil]}, default: nil],
       background: [type: {:or, [:string, {:in, [:theme]}, nil]}, default: nil],
       width: [type: {:or, [:pos_integer, nil]}, default: nil],
       rainbow_brackets: [type: :boolean, default: false]
@@ -893,7 +894,7 @@ defmodule Lumis do
   ## Examples
 
       iex> Lumis.validate_options!(formatter: {:html_inline, language: "elixir"})
-      [formatter: {:html_inline, [header: nil, highlight_lines: nil, include_highlights: false, italic: false, pre_class: nil, theme: "onedark", language: "elixir"]}]
+      [formatter: {:html_inline, [header: nil, highlight_lines: nil, include_highlights: false, italic: false, pre_class: nil, theme: nil, language: "elixir"]}]
 
       iex> Lumis.validate_options!(formatter: {:html_inline, theme: "dracula"})
       [formatter: {:html_inline, [theme: "dracula", ...]}]

--- a/packages/elixir/lumis/test/lumis_test.exs
+++ b/packages/elixir/lumis/test/lumis_test.exs
@@ -22,9 +22,10 @@ defmodule Lumis.LumisTest do
   describe "deprecated still works" do
     test "highlight" do
       capture_io(:stderr, fn ->
-        assert {:ok, hl} = Lumis.highlight("elixir", ":test")
+        assert {:ok, hl} = Lumis.highlight("elixir", ":test", theme: "onedark")
 
-        assert hl =~ ~s|<pre class="lumis"><code class="language-elixir"|
+        assert hl =~
+                 ~s|<pre class="lumis" style="color: #abb2bf; background-color: #282c34;"><code class="language-elixir"|
 
         assert {:ok, hl} = Lumis.highlight("elixir", ":test", theme: "dracula")
 
@@ -53,8 +54,8 @@ defmodule Lumis.LumisTest do
 
     test "highlight!" do
       capture_io(:stderr, fn ->
-        assert Lumis.highlight!("elixir", ":test") =~
-                 ~s|<pre class="lumis"><code class="language-elixir"|
+        assert Lumis.highlight!("elixir", ":test", theme: "onedark") =~
+                 ~s|<pre class="lumis" style="color: #abb2bf; background-color: #282c34;"><code class="language-elixir"|
 
         assert Lumis.highlight!("elixir", ":test", theme: "dracula") =~
                  ~s|<pre class="lumis" style="color: #f8f8f2; background-color: #282a36;"><code class="language-elixir"|
@@ -74,8 +75,12 @@ defmodule Lumis.LumisTest do
     test "inline_style option" do
       capture_io(:stderr, fn ->
         assert {:ok,
-                "<pre class=\"lumis\"><code class=\"language-elixir\" translate=\"no\" tabindex=\"0\"><div class=\"l-line\" data-line=\"1\"><span >:test</span>\n</div></code></pre>"} =
-                 Lumis.highlight(":test", language: "elixir", inline_style: true)
+                "<pre class=\"lumis\" style=\"color: #abb2bf; background-color: #282c34;\"><code class=\"language-elixir\" translate=\"no\" tabindex=\"0\"><div class=\"l-line\" data-line=\"1\"><span style=\"color: #e06c75;\">:test</span>\n</div></code></pre>"} =
+                 Lumis.highlight(":test",
+                   language: "elixir",
+                   theme: "onedark",
+                   inline_style: true
+                 )
       end)
     end
 
@@ -358,12 +363,12 @@ defmodule Lumis.LumisTest do
       assert_output(
         "defmodule Test do\n  @lang :elixir\nend",
         ~s"""
-        <pre class="lumis"><code class="language-elixir" translate="no" tabindex="0"><div class="l-line" data-line="1"><span >defmodule</span> <span >Test</span> <span >do</span>
-        </div><div class="l-line" data-line="2">  <span ><span >@<span ><span >lang <span >:elixir</span></span></span></span></span>
-        </div><div class="l-line" data-line="3"><span >end</span>
+        <pre class="lumis" style="color: #abb2bf; background-color: #282c34;"><code class="language-elixir" translate="no" tabindex="0"><div class="l-line" data-line="1"><span style="color: #c678dd;">defmodule</span> <span style="color: #e5c07b;">Test</span> <span style="color: #c678dd;">do</span>
+        </div><div class="l-line" data-line="2">  <span style="color: #56b6c2;"><span style="color: #d19a66;">@<span style="color: #61afef;"><span style="color: #d19a66;">lang <span style="color: #e06c75;">:elixir</span></span></span></span></span>
+        </div><div class="l-line" data-line="3"><span style="color: #c678dd;">end</span>
         </div></code></pre>
         """,
-        formatter: {:html_inline, language: "elixir"}
+        formatter: {:html_inline, language: "elixir", theme: "onedark"}
       )
     end
 
@@ -443,8 +448,8 @@ defmodule Lumis.LumisTest do
     test "with default opts" do
       assert_output(
         "defmodule Test do\n  @lang :elixir\nend",
-        "defmodule Test do\n  @lang :elixir\nend",
-        formatter: {:terminal, language: "elixir"}
+        "\e[0m\e[38;2;198;120;221mdefmodule\e[0m \e[0m\e[38;2;229;192;123mTest\e[0m \e[0m\e[38;2;198;120;221mdo\e[0m\n  \e[0m\e[38;2;209;154;102m@\e[0m\e[0m\e[38;2;209;154;102mlang \e[0m\e[0m\e[38;2;224;108;117m:elixir\e[0m\n\e[0m\e[38;2;198;120;221mend\e[0m",
+        formatter: {:terminal, language: "elixir", theme: "onedark"}
       )
     end
 

--- a/packages/elixir/lumis/test/lumis_test.exs
+++ b/packages/elixir/lumis/test/lumis_test.exs
@@ -24,8 +24,7 @@ defmodule Lumis.LumisTest do
       capture_io(:stderr, fn ->
         assert {:ok, hl} = Lumis.highlight("elixir", ":test")
 
-        assert hl =~
-                 ~s|<pre class="lumis" style="color: #abb2bf; background-color: #282c34;"><code class="language-elixir"|
+        assert hl =~ ~s|<pre class="lumis"><code class="language-elixir"|
 
         assert {:ok, hl} = Lumis.highlight("elixir", ":test", theme: "dracula")
 
@@ -55,7 +54,7 @@ defmodule Lumis.LumisTest do
     test "highlight!" do
       capture_io(:stderr, fn ->
         assert Lumis.highlight!("elixir", ":test") =~
-                 ~s|<pre class="lumis" style="color: #abb2bf; background-color: #282c34;"><code class="language-elixir"|
+                 ~s|<pre class="lumis"><code class="language-elixir"|
 
         assert Lumis.highlight!("elixir", ":test", theme: "dracula") =~
                  ~s|<pre class="lumis" style="color: #f8f8f2; background-color: #282a36;"><code class="language-elixir"|
@@ -75,7 +74,7 @@ defmodule Lumis.LumisTest do
     test "inline_style option" do
       capture_io(:stderr, fn ->
         assert {:ok,
-                "<pre class=\"lumis\" style=\"color: #abb2bf; background-color: #282c34;\"><code class=\"language-elixir\" translate=\"no\" tabindex=\"0\"><div class=\"l-line\" data-line=\"1\"><span style=\"color: #e06c75;\">:test</span>\n</div></code></pre>"} =
+                "<pre class=\"lumis\"><code class=\"language-elixir\" translate=\"no\" tabindex=\"0\"><div class=\"l-line\" data-line=\"1\"><span >:test</span>\n</div></code></pre>"} =
                  Lumis.highlight(":test", language: "elixir", inline_style: true)
       end)
     end
@@ -156,7 +155,7 @@ defmodule Lumis.LumisTest do
                language: nil,
                header: nil,
                italic: false,
-               theme: "onedark",
+               theme: nil,
                pre_class: nil,
                include_highlights: false,
                rainbow_brackets: false,
@@ -174,7 +173,7 @@ defmodule Lumis.LumisTest do
                [
                  language: nil,
                  italic: false,
-                 theme: "onedark",
+                 theme: nil,
                  pre_class: nil,
                  include_highlights: false,
                  rainbow_brackets: false,
@@ -210,7 +209,7 @@ defmodule Lumis.LumisTest do
       assert Keyword.equal?(
                [
                  language: nil,
-                 theme: "onedark",
+                 theme: nil,
                  background: nil,
                  width: nil,
                  rainbow_brackets: false
@@ -244,7 +243,9 @@ defmodule Lumis.LumisTest do
 
     test "terminal with language" do
       assert {:ok, result} =
-               Lumis.highlight(":test", formatter: {:terminal, language: "elixir"})
+               Lumis.highlight(":test",
+                 formatter: {:terminal, language: "elixir", theme: "onedark"}
+               )
 
       assert result =~ "\e[0m"
     end
@@ -357,9 +358,9 @@ defmodule Lumis.LumisTest do
       assert_output(
         "defmodule Test do\n  @lang :elixir\nend",
         ~s"""
-        <pre class="lumis" style="color: #abb2bf; background-color: #282c34;"><code class="language-elixir" translate="no" tabindex="0"><div class="l-line" data-line="1"><span style="color: #c678dd;">defmodule</span> <span style="color: #e5c07b;">Test</span> <span style="color: #c678dd;">do</span>
-        </div><div class="l-line" data-line="2">  <span style="color: #56b6c2;"><span style="color: #d19a66;">@<span style="color: #61afef;"><span style="color: #d19a66;">lang <span style="color: #e06c75;">:elixir</span></span></span></span></span>
-        </div><div class="l-line" data-line="3"><span style="color: #c678dd;">end</span>
+        <pre class="lumis"><code class="language-elixir" translate="no" tabindex="0"><div class="l-line" data-line="1"><span >defmodule</span> <span >Test</span> <span >do</span>
+        </div><div class="l-line" data-line="2">  <span ><span >@<span ><span >lang <span >:elixir</span></span></span></span></span>
+        </div><div class="l-line" data-line="3"><span >end</span>
         </div></code></pre>
         """,
         formatter: {:html_inline, language: "elixir"}
@@ -409,7 +410,7 @@ defmodule Lumis.LumisTest do
         </div><div class="l-line" data-line="3"><span data-highlight="keyword" style="color: #c678dd;">end</span>
         </div></code></pre>
         """,
-        formatter: {:html_inline, language: "elixir", include_highlights: true}
+        formatter: {:html_inline, language: "elixir", theme: "onedark", include_highlights: true}
       )
     end
   end
@@ -442,7 +443,7 @@ defmodule Lumis.LumisTest do
     test "with default opts" do
       assert_output(
         "defmodule Test do\n  @lang :elixir\nend",
-        "\e[0m\e[38;2;198;120;221mdefmodule\e[0m \e[0m\e[38;2;229;192;123mTest\e[0m \e[0m\e[38;2;198;120;221mdo\e[0m\n  \e[0m\e[38;2;209;154;102m@\e[0m\e[0m\e[38;2;209;154;102mlang \e[0m\e[0m\e[38;2;224;108;117m:elixir\e[0m\n\e[0m\e[38;2;198;120;221mend\e[0m",
+        "defmodule Test do\n  @lang :elixir\nend",
         formatter: {:terminal, language: "elixir"}
       )
     end
@@ -745,7 +746,8 @@ defmodule Lumis.LumisTest do
       result =
         Lumis.highlight!(
           "def test\n  puts 'hello'\nend",
-          formatter: {:html_inline, language: "ruby", highlight_lines: highlight_lines}
+          formatter:
+            {:html_inline, language: "ruby", theme: "onedark", highlight_lines: highlight_lines}
         )
 
       assert String.contains?(
@@ -1027,7 +1029,7 @@ defmodule Lumis.LumisTest do
                  rainbow_brackets: false,
                  italic: false,
                  pre_class: nil,
-                 theme: "onedark",
+                 theme: nil,
                  language: "elixir"
                ],
                formatter_opts
@@ -1046,7 +1048,7 @@ defmodule Lumis.LumisTest do
                  rainbow_brackets: false,
                  italic: false,
                  pre_class: nil,
-                 theme: "onedark",
+                 theme: nil,
                  language: nil
                ],
                formatter_opts
@@ -1085,7 +1087,7 @@ defmodule Lumis.LumisTest do
                       include_highlights: false,
                       italic: false,
                       pre_class: nil,
-                      theme: "onedark"
+                      theme: nil
                     ]},
                  theme: "dracula",
                  inline_style: true,
@@ -1112,7 +1114,7 @@ defmodule Lumis.LumisTest do
                  rainbow_brackets: false,
                  italic: false,
                  pre_class: nil,
-                 theme: "onedark"
+                 theme: nil
                ],
                formatter_opts
              )
@@ -1135,7 +1137,7 @@ defmodule Lumis.LumisTest do
                    rainbow_brackets: false,
                    italic: false,
                    pre_class: nil,
-                   theme: "onedark"
+                   theme: nil
                  ],
                  formatter_opts
                )
@@ -1188,7 +1190,7 @@ defmodule Lumis.LumisTest do
           formatter: {:html_inline, language: "rust"}
         )
 
-      assert %{language: "rust", formatter: {:html_inline, %{theme: {:string, "onedark"}}}} =
+      assert %{language: "rust", formatter: {:html_inline, %{theme: nil}}} =
                Lumis.rust_options!(options)
     end
 
@@ -1232,7 +1234,7 @@ defmodule Lumis.LumisTest do
                       include_highlights: false,
                       italic: false,
                       pre_class: "deprecated-class",
-                      theme: {:string, "onedark"}
+                      theme: nil
                     }}
                } = Lumis.rust_options!(options)
       end)
@@ -1408,7 +1410,7 @@ defmodule Lumis.LumisTest do
                     include_highlights: false,
                     italic: false,
                     pre_class: nil,
-                    theme: {:string, "onedark"}
+                    theme: nil
                   }}
              } = Lumis.rust_options!(options)
     end
@@ -1426,7 +1428,7 @@ defmodule Lumis.LumisTest do
                     include_highlights: false,
                     italic: false,
                     pre_class: nil,
-                    theme: {:string, "onedark"}
+                    theme: nil
                   }}
              } = Lumis.rust_options!(options)
     end


### PR DESCRIPTION
Running `cargo run --example auto_detect_language` produced HTML with no colors at all — every token came out as `<span >`.

The example never set a theme. `HtmlInline`'s `theme` defaults to `None` (`crates/lumis/src/formatter/html_inline.rs:213`), and with no theme `span_inline_attrs` returns an empty string, so the spans carry nothing. Highlighting itself was fine: Python was detected from the shebang, the tree parsed, the scopes captured. Only the style lookup had nothing to look up in.

Auditing that turned up a second, larger problem: the runtimes disagreed on what the default is.

## Aligning the default on none

| Runtime | Before | After |
| --- | --- | --- |
| Rust | `None` | unchanged |
| JavaScript | `theme?: Theme` (undefined) | unchanged |
| Elixir | `"onedark"` | `nil` |
| CLI | `--theme auto` | unchanged |

Elixir set `@default_theme "onedark"` on both `:html_inline` and `:terminal`, and again in the top-level formatter default (`{:html_inline, theme: "onedark"}`). Its own docs already documented the default as `nil`, so the code and the docs had been contradicting each other; nothing failed because no test compared output across runtimes.

Rust is the reference implementation, so Elixir converges on it. No runtime picks a theme on your behalf.

The CLI keeps `--theme auto`. It is an application consuming the API rather than a definition of it: it detects the terminal background, picks the closest built-in theme, and already returns no theme when detection fails. It chooses a theme the way an example does.

## Examples and docs

A no-theme default is only safe if the examples set a theme. Swept every runtime; these were missing one:

- `crates/lumis/examples/auto_detect_language.rs` — the reported bug, the only Rust example of 14 without a theme
- `crates/lumis/src/lib.rs` — rustdoc for `highlight()` and `write_highlight()`
- `docs/content/usage/rust-advanced.mdx` — both blocks
- `docs/content/recipes/stream-output-to-a-file-rust.mdx`

Elixir docs and examples that had been relying on the implicit `"onedark"` now pass a theme explicitly: the package README, the four complete examples in `elixir-integration.mdx`, and the `Lumis` moduledoc snippets. The moduledoc snippets using `style: :theme` mattered most — that option looks up the theme's `highlighted` style, so without a theme it silently does nothing.

Everything else already set a theme: the JS examples, the rehype/markdown-it/react integration examples, the Livebooks, the website, and the rest of the docs site.

## Tests

The Elixir suite pinned the old default in 13 places. Split by intent rather than mechanically:

- tests named "default opts" now assert the **new** unstyled output, since documenting the default is their job
- feature tests (`include_highlights`, theme-based `highlight_lines`, terminal ANSI) got an explicit `theme: "onedark"`, so they keep testing the feature instead of quietly testing nothing

## Verification

- `mix test` — 131 passed
- `mix test --include conformance` — 266 passed
- `cargo test -p lumis` — 208 + 66 doctests passed
- `cargo clippy --examples`, `mise run lint` — clean
- `cargo run --example auto_detect_language` now emits `style="color: #c678dd;"` and a themed `<pre>` background

## Breaking change

`Lumis.highlight/2` with `:html_inline` or `:terminal` and no `:theme` now returns uncolored output. Pass `theme: "onedark"` to keep the previous rendering.

## Left alone, deliberately

`render_lines_from_events` (`crates/lumis-core/src/formatter/html.rs:600`) always writes `<span {attrs}>`, so an empty attrs produces `<span >` with a stray space — that is where the reported symptom got its shape. The public `span_inline` helper drops the span entirely in the same situation (`html.rs:65`), so the two paths disagree. JavaScript reproduces the stray space on purpose (`packages/javascript/lumis/src/formatter/html.ts:326` and `:988`, both literal `"<span >"`), presumably to hold conformance. Every conformance fixture names a theme, so this path is only pinned by unit tests. Worth cleaning up, but it is a coordinated Rust + JS change and is not this PR.
